### PR TITLE
incident response: interactive sync + notification suppression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,33 +12,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
-      - run: uv run ruff check src/ tests/
+      - run: uv run --extra dev ruff check src/ tests/
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
-      - run: uv run pytest tests/test_*.py -v
+      - run: uv run --extra dev pytest tests/test_*.py -v
 
   e2e:
     runs-on: ubuntu-latest
-    services:
-      radicale:
-        image: tomsquest/docker-radicale:latest
-        ports:
-          - 15232:5232
-        volumes:
-          - ${{ github.workspace }}/tests/e2e/radicale/config:/config/config
-          - ${{ github.workspace }}/tests/e2e/radicale/users:/config/users
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
-      - run: uv run pytest tests/e2e/ -m e2e -v
+      - name: Start Radicale
+        run: |
+          docker run -d --name radicale \
+            -p 15232:5232 \
+            -v "${{ github.workspace }}/tests/e2e/radicale/config:/config/config" \
+            -v "${{ github.workspace }}/tests/e2e/radicale/users:/config/users" \
+            tomsquest/docker-radicale:latest
+      - name: Wait for Radicale
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null http://localhost:15232/; then
+              echo "Radicale is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Radicale failed to start" >&2
+          docker logs radicale >&2 || true
+          exit 1
+      - run: uv run --extra dev pytest tests/e2e/ -m e2e -v
+      - name: Stop Radicale
+        if: always()
+        run: docker stop radicale || true
 
   vuln-scan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
-      - run: uv run pip-audit
+      - run: uv run --extra dev pip-audit

--- a/src/groupware_sync/engine.py
+++ b/src/groupware_sync/engine.py
@@ -96,7 +96,7 @@ def sync_trees(
 
     if dry_run:
         # Log the plan without executing
-        _log_dry_run(operations, provider_a.name, provider_b.name, summary)
+        _log_dry_run(operations, provider_a, provider_b, summary)
         log.info("Dry run complete — no changes made")
         return summary
 
@@ -129,58 +129,115 @@ def sync_trees(
 # ---------------------------------------------------------------------------
 
 
-def _log_dry_run(
-    operations: list[SyncOp],
-    prov_a_name: str,
-    prov_b_name: str,
-    summary: SyncSummary,
-) -> None:
-    """Log what each operation would do, and populate the summary counts.
+def _annotation_for_op(
+    op: SyncOp,
+    provider_a: SyncProvider,
+    provider_b: SyncProvider,
+) -> str:
+    """Return '' or '    [!] notifications best-effort/unsupported' for an op."""
+    from groupware_sync.provider import NotificationCapability
 
-    NOTE: The create count may be inflated on first sync because identity
-    matching (which pairs items by email/name across sides) only runs during
-    execution. Items that appear as creates on both sides may actually be
-    matched and merged instead.
-    """
+    def cap_for(side: str, op_field: str) -> Optional[NotificationCapability]:
+        prov = provider_b if side == "b" else provider_a
+        return getattr(prov.notification_policy, op_field)
+
+    caps: list[NotificationCapability] = []
+    if op.op_type == OpType.CREATE_ITEM:
+        caps.append(cap_for(op.target_side, "create_item"))
+    elif op.op_type == OpType.CREATE_CONTAINER:
+        # create_container is not in the policy struct; treat as unannotated.
+        return ""
+    elif op.op_type == OpType.DELETE_ITEM:
+        if op.target_side == "both":
+            return ""  # already gone on both sides, no write
+        caps.append(cap_for(op.target_side, "delete_item"))
+    elif op.op_type == OpType.DELETE_CONTAINER:
+        caps.append(cap_for(op.target_side, "delete_container"))
+    elif op.op_type == OpType.MERGE_ITEM:
+        # Merge may update either side; consider both.
+        caps.append(provider_a.notification_policy.update_item)
+        caps.append(provider_b.notification_policy.update_item)
+    else:
+        return ""
+
+    worst = NotificationCapability.SUPPRESSED
+    for c in caps:
+        if c is NotificationCapability.UNSUPPORTED:
+            worst = NotificationCapability.UNSUPPORTED
+            break
+        if c is NotificationCapability.BEST_EFFORT:
+            worst = NotificationCapability.BEST_EFFORT
+    if worst is NotificationCapability.SUPPRESSED:
+        return ""
+    return f"    [!] notifications {worst.value}"
+
+
+def _format_plan(
+    operations: list[SyncOp],
+    provider_a: SyncProvider,
+    provider_b: SyncProvider,
+) -> list[str]:
+    """Produce one 'PLAN ...' line per op, with optional suppression annotation."""
+    lines: list[str] = []
+    for op in operations:
+        suffix = _annotation_for_op(op, provider_a, provider_b)
+        if op.op_type == OpType.SKIP_SUBTREE:
+            base = f"PLAN SKIP_SUBTREE {op.node_id}"
+        elif op.op_type == OpType.CREATE_CONTAINER:
+            target = provider_b.name if op.target_side == "b" else provider_a.name
+            base = f'PLAN CREATE_CONTAINER "{op.container_name or op.node_id}" on {target}'
+        elif op.op_type == OpType.CREATE_ITEM:
+            target = provider_b.name if op.target_side == "b" else provider_a.name
+            base = f"PLAN CREATE_ITEM {op.node_id} on {target}"
+        elif op.op_type == OpType.MERGE_ITEM:
+            base = f"PLAN MERGE_ITEM {op.node_id} <-> {op.paired_node_id}"
+        elif op.op_type == OpType.DELETE_ITEM:
+            if op.target_side == "both":
+                base = f"PLAN DELETE_ITEM {op.node_id} <-> {op.paired_node_id} (both gone)"
+            else:
+                target = provider_b.name if op.target_side == "b" else provider_a.name
+                base = f"PLAN DELETE_ITEM {op.node_id} on {target}"
+        elif op.op_type == OpType.DELETE_CONTAINER:
+            target = provider_b.name if op.target_side == "b" else provider_a.name
+            base = f"PLAN DELETE_CONTAINER {op.node_id} on {target}"
+        else:
+            base = f"PLAN {op.op_type.value} {op.node_id}"
+        lines.append(base + suffix)
+    return lines
+
+
+def _populate_plan_summary(operations: list[SyncOp], summary: SyncSummary) -> None:
+    """Populate plan counts onto a summary (mutating)."""
     from collections import Counter
 
     counts = Counter(op.op_type for op in operations)
-    creates_a = sum(1 for op in operations if op.op_type == OpType.CREATE_ITEM and op.target_side == "a")
-    creates_b = sum(1 for op in operations if op.op_type == OpType.CREATE_ITEM and op.target_side == "b")
     summary.created = counts.get(OpType.CREATE_ITEM, 0)
     summary.deleted = counts.get(OpType.DELETE_ITEM, 0)
     summary.updated = counts.get(OpType.MERGE_ITEM, 0)
     summary.containers = counts.get(OpType.CREATE_CONTAINER, 0)
     summary.skipped = counts.get(OpType.SKIP_SUBTREE, 0)
 
+
+def _log_dry_run(
+    operations: list[SyncOp],
+    provider_a: SyncProvider,
+    provider_b: SyncProvider,
+    summary: SyncSummary,
+) -> None:
+    """Log the plan and populate summary counts. Called from sync_trees when dry_run=True."""
+    lines = _format_plan(operations, provider_a, provider_b)
+    for line in lines:
+        log.info("[dry-run] %s", line)
+    _populate_plan_summary(operations, summary)
+    creates_a = sum(1 for op in operations if op.op_type == OpType.CREATE_ITEM and op.target_side == "a")
+    creates_b = sum(1 for op in operations if op.op_type == OpType.CREATE_ITEM and op.target_side == "b")
     if creates_a > 0 and creates_b > 0:
         log.info(
             "[dry-run] NOTE: %d creates on %s + %d creates on %s — "
             "identity matching may reduce this (items with shared emails "
             "will be merged instead of duplicated)",
-            creates_b, prov_a_name, creates_a, prov_b_name,
+            creates_b, provider_a.name, creates_a, provider_b.name,
         )
-
-    for op in operations:
-        if op.op_type == OpType.SKIP_SUBTREE:
-            log.info("[dry-run] SKIP subtree %s", op.node_id)
-        elif op.op_type == OpType.CREATE_CONTAINER:
-            target = prov_b_name if op.target_side == "b" else prov_a_name
-            log.info("[dry-run] CREATE container %r on %s", op.container_name, target)
-        elif op.op_type == OpType.CREATE_ITEM:
-            target = prov_b_name if op.target_side == "b" else prov_a_name
-            log.info("[dry-run] CREATE item %s on %s", op.node_id, target)
-        elif op.op_type == OpType.MERGE_ITEM:
-            log.info("[dry-run] MERGE item %s ↔ %s", op.node_id, op.paired_node_id)
-        elif op.op_type == OpType.DELETE_ITEM:
-            if op.target_side == "both":
-                log.info("[dry-run] DELETE (both gone) %s ↔ %s", op.node_id, op.paired_node_id)
-            else:
-                target = prov_b_name if op.target_side == "b" else prov_a_name
-                log.info("[dry-run] DELETE item %s on %s", op.node_id, target)
-        elif op.op_type == OpType.DELETE_CONTAINER:
-            target = prov_b_name if op.target_side == "b" else prov_a_name
-            log.info("[dry-run] DELETE container %s on %s", op.node_id, target)
 
 
 # ---------------------------------------------------------------------------

--- a/src/groupware_sync/engine.py
+++ b/src/groupware_sync/engine.py
@@ -116,7 +116,7 @@ def sync_trees(
             f" created={plan_summary.created}"
             f" updated={plan_summary.updated}"
             f" deleted={plan_summary.deleted}"
-            f" conflicts=0 skipped={plan_summary.skipped}"
+            f" skipped={plan_summary.skipped}"
         )
         print(summary_line, file=sys.stdout)
         if any("[!]" in line for line in lines):

--- a/src/groupware_sync/engine.py
+++ b/src/groupware_sync/engine.py
@@ -24,7 +24,7 @@ from groupware_sync.models import (
     SyncSummary,
     TypeSpec,
 )
-from groupware_sync.provider import SyncProvider
+from groupware_sync.provider import NotificationCapability, SyncProvider
 from groupware_sync.state import ops
 from groupware_sync.tree import compare_trees
 
@@ -135,9 +135,8 @@ def _annotation_for_op(
     provider_b: SyncProvider,
 ) -> str:
     """Return '' or '    [!] notifications best-effort/unsupported' for an op."""
-    from groupware_sync.provider import NotificationCapability
 
-    def cap_for(side: str, op_field: str) -> Optional[NotificationCapability]:
+    def cap_for(side: str, op_field: str) -> NotificationCapability:
         prov = provider_b if side == "b" else provider_a
         return getattr(prov.notification_policy, op_field)
 

--- a/src/groupware_sync/engine.py
+++ b/src/groupware_sync/engine.py
@@ -102,8 +102,12 @@ def sync_trees(
         return summary
 
     if confirm is not None:
-        if not operations:
-            log.info("Plan is empty — nothing to confirm, no writes to execute")
+        if not _has_write_op(operations):
+            # Empty plan or a plan that is only SKIP_SUBTREE / both-gone
+            # reconciliations: no writes to confirm. Populate summary so the
+            # caller can still report skipped counts, then return.
+            _populate_plan_summary(operations, summary)
+            log.info("Plan has no writes — nothing to confirm, no writes to execute")
             return summary
 
         plan_summary = SyncSummary()
@@ -159,6 +163,27 @@ def sync_trees(
 # ---------------------------------------------------------------------------
 # Dry-run reporting
 # ---------------------------------------------------------------------------
+
+
+def _has_write_op(operations: list[SyncOp]) -> bool:
+    """True if any op would cause a write on either side.
+
+    SKIP_SUBTREE is purely informational (subtree matched stored state).
+    DELETE_ITEM with target_side='both' is a mapping cleanup (both sides
+    already deleted). Neither triggers a provider write, so a plan
+    consisting only of these should not prompt the user.
+    """
+    for op in operations:
+        if op.op_type in (
+            OpType.CREATE_CONTAINER,
+            OpType.CREATE_ITEM,
+            OpType.MERGE_ITEM,
+            OpType.DELETE_CONTAINER,
+        ):
+            return True
+        if op.op_type == OpType.DELETE_ITEM and op.target_side != "both":
+            return True
+    return False
 
 
 def _annotation_for_op(

--- a/src/groupware_sync/engine.py
+++ b/src/groupware_sync/engine.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import sys
 from collections import defaultdict
-from typing import Optional
+from typing import Callable, Optional
 
 from sqlalchemy.orm import Session
 
@@ -43,6 +44,7 @@ def sync_trees(
     type_spec: TypeSpec,
     session: Session,
     dry_run: bool = False,
+    confirm: Optional[Callable[[list[SyncOp], SyncSummary], bool]] = None,
 ) -> SyncSummary:
     """Run a full two-way tree sync between two providers.
 
@@ -95,10 +97,40 @@ def sync_trees(
     log.info("Phase 3 produced %d operations", len(operations))
 
     if dry_run:
-        # Log the plan without executing
         _log_dry_run(operations, provider_a, provider_b, summary)
         log.info("Dry run complete — no changes made")
         return summary
+
+    if confirm is not None:
+        if not operations:
+            log.info("Plan is empty — nothing to confirm, no writes to execute")
+            return summary
+
+        plan_summary = SyncSummary()
+        _populate_plan_summary(operations, plan_summary)
+        lines = _format_plan(operations, provider_a, provider_b)
+        for line in lines:
+            print(line, file=sys.stdout)
+        summary_line = (
+            f"SUMMARY containers={plan_summary.containers}"
+            f" created={plan_summary.created}"
+            f" updated={plan_summary.updated}"
+            f" deleted={plan_summary.deleted}"
+            f" conflicts=0 skipped={plan_summary.skipped}"
+        )
+        print(summary_line, file=sys.stdout)
+        if any("[!]" in line for line in lines):
+            print(
+                "NOTE: some ops may emit attendee notifications (see [!] markers above)",
+                file=sys.stdout,
+            )
+
+        approved = confirm(operations, plan_summary)
+        if not approved:
+            _populate_plan_summary(operations, summary)
+            summary.aborted = True
+            log.info("Sync aborted by user — no writes executed")
+            return summary
 
     # Phase 4 — Execute operations
     log.info("Phase 4: executing operations")

--- a/src/groupware_sync/models.py
+++ b/src/groupware_sync/models.py
@@ -158,3 +158,4 @@ class SyncSummary:
     conflicts: int = 0
     skipped: int = 0
     errors: int = 0
+    aborted: bool = False

--- a/src/groupware_sync/provider.py
+++ b/src/groupware_sync/provider.py
@@ -6,13 +6,38 @@ protocol-specific tree building, item fetching, and CRUD operations.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
 from typing import Optional
 
 from groupware_sync.models import ChangeSet, ItemType, SyncItem, SyncNode
 
 
+class NotificationCapability(Enum):
+    """Per-op-type capability for suppressing scheduling/notification traffic."""
+
+    SUPPRESSED = "suppressed"
+    BEST_EFFORT = "best-effort"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class NotificationPolicy:
+    """An adapter's declared suppression capability for each write op."""
+
+    create_item: NotificationCapability
+    update_item: NotificationCapability
+    delete_item: NotificationCapability
+    delete_container: NotificationCapability
+
+
 class SyncProvider(ABC):
     """Abstract base class for a groupware backend."""
+
+    # Required class attribute: declare what suppression the adapter provides.
+    # Adapters MUST override this; no default is provided because a silent
+    # default of SUPPRESSED would hide real gaps.
+    notification_policy: NotificationPolicy
 
     @property
     @abstractmethod

--- a/src/groupware_sync_calendar/adapters/caldav_adapter.py
+++ b/src/groupware_sync_calendar/adapters/caldav_adapter.py
@@ -24,7 +24,11 @@ from groupware_sync.models import (
     SyncItem,
     SyncNode,
 )
-from groupware_sync.provider import SyncProvider
+from groupware_sync.provider import (
+    NotificationCapability,
+    NotificationPolicy,
+    SyncProvider,
+)
 from groupware_sync_calendar import tz
 
 log = logging.getLogger(__name__)
@@ -62,6 +66,13 @@ _PARTSTAT_REVERSE: dict[str, str] = {v: k for k, v in _PARTSTAT_MAP.items()}
 
 class CalDavCalendarAdapter(SyncProvider):
     """SyncProvider implementation backed by a CalDAV server."""
+
+    notification_policy = NotificationPolicy(
+        create_item=NotificationCapability.UNSUPPORTED,
+        update_item=NotificationCapability.UNSUPPORTED,
+        delete_item=NotificationCapability.UNSUPPORTED,
+        delete_container=NotificationCapability.UNSUPPORTED,
+    )
 
     def __init__(
         self,

--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -23,7 +23,11 @@ from groupware_sync.models import (
     SyncItem,
     SyncNode,
 )
-from groupware_sync.provider import SyncProvider
+from groupware_sync.provider import (
+    NotificationCapability,
+    NotificationPolicy,
+    SyncProvider,
+)
 from groupware_sync_calendar.rrule import graph_recurrence_to_rrule, rrule_to_graph_recurrence
 from groupware_sync_calendar.tz import from_utc, iana_to_windows, to_utc, windows_to_iana
 
@@ -109,6 +113,13 @@ def _priority_to_importance(priority: int) -> str:
 class GraphCalendarAdapter(SyncProvider):
     """SyncProvider implementation for Microsoft Graph calendar events."""
 
+    notification_policy = NotificationPolicy(
+        create_item=NotificationCapability.BEST_EFFORT,
+        update_item=NotificationCapability.BEST_EFFORT,
+        delete_item=NotificationCapability.BEST_EFFORT,
+        delete_container=NotificationCapability.BEST_EFFORT,
+    )
+
     def __init__(
         self, access_token: str, calendar_filter: Optional[str] = None
     ) -> None:
@@ -145,6 +156,21 @@ class GraphCalendarAdapter(SyncProvider):
             )
             time.sleep(retry_after)
         return resp  # unreachable, but keeps mypy happy
+
+    def _write_request(
+        self, method: str, url: str, **kwargs: Any
+    ) -> httpx.Response:
+        """Variant of _request that adds the notification-suppression Prefer
+        header. Use for POST/PATCH/DELETE on events and event-bearing
+        endpoints. Read paths stay on _request to keep the header off GETs.
+        """
+        headers = dict(kwargs.pop("headers", None) or {})
+        existing_prefer = headers.get("Prefer", "")
+        suppress = "outlook.send-notifications=false"
+        headers["Prefer"] = (
+            f"{existing_prefer}, {suppress}" if existing_prefer else suppress
+        )
+        return self._request(method, url, headers=headers, **kwargs)
 
     # -- SyncProvider interface ------------------------------------------------
 
@@ -317,19 +343,19 @@ class GraphCalendarAdapter(SyncProvider):
         self, name: str, parent_id: Optional[str] = None
     ) -> str:
         """Create a calendar, return its provider ID."""
-        r = self._request("POST", "/me/calendars", json={"name": name})
+        r = self._write_request("POST", "/me/calendars", json={"name": name})
         r.raise_for_status()
         return r.json()["id"]
 
     def delete_container(self, container_id: str) -> None:
         """Delete a calendar."""
-        r = self._request("DELETE", f"/me/calendars/{container_id}")
+        r = self._write_request("DELETE", f"/me/calendars/{container_id}")
         r.raise_for_status()
 
     def create_item(self, container_id: str, item: SyncItem) -> tuple[str, str]:
         """Create an event. Returns (new_id, server_fingerprint)."""
         body = _sync_item_to_graph(item)
-        r = self._request(
+        r = self._write_request(
             "POST", f"/me/calendars/{container_id}/events", json=body
         )
         r.raise_for_status()
@@ -339,13 +365,13 @@ class GraphCalendarAdapter(SyncProvider):
     def update_item(self, container_id: str, item: SyncItem) -> str:
         """Update an existing event. Returns server-assigned fingerprint."""
         body = _sync_item_to_graph(item)
-        r = self._request("PATCH", f"/me/events/{item.provider_id}", json=body)
+        r = self._write_request("PATCH", f"/me/events/{item.provider_id}", json=body)
         r.raise_for_status()
         return r.json().get("lastModifiedDateTime", "")
 
     def delete_item(self, container_id: str, item_id: str) -> None:
         """Delete an event. Silently ignores 404 (already gone)."""
-        r = self._request("DELETE", f"/me/events/{item_id}")
+        r = self._write_request("DELETE", f"/me/events/{item_id}")
         if r.status_code == 404:
             log.info("graph event %s already deleted", item_id)
             return

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -362,12 +362,19 @@ class JmapCalendarAdapter(SyncProvider):
         ])
         for result in results:
             if result[0] == "CalendarEvent/set":
+                not_created = result[1].get("notCreated", {})
+                if "new1" in not_created:
+                    err = not_created["new1"]
+                    raise ValueError(
+                        f"JMAP create calendar event failed: "
+                        f"{err.get('type', 'unknown')} — {err.get('description', '')}"
+                    )
                 created = result[1].get("created", {})
                 new_item = created.get("new1", {})
                 new_id = new_item["id"]
                 fingerprint = new_item.get("updated", "")
                 return new_id, fingerprint
-        raise ValueError("JMAP create calendar event failed")
+        raise ValueError("JMAP create calendar event failed: no CalendarEvent/set in response")
 
     def update_item(self, container_id: str, item: SyncItem) -> str:
         """Update an existing calendar event. Returns server-assigned fingerprint."""

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -23,7 +23,11 @@ from groupware_sync.models import (
     SyncItem,
     SyncNode,
 )
-from groupware_sync.provider import SyncProvider
+from groupware_sync.provider import (
+    NotificationCapability,
+    NotificationPolicy,
+    SyncProvider,
+)
 from groupware_sync_calendar import tz
 
 log = logging.getLogger(__name__)
@@ -71,6 +75,13 @@ _VALID_FREQ = {"YEARLY", "MONTHLY", "WEEKLY", "DAILY", "HOURLY", "MINUTELY", "SE
 
 class JmapCalendarAdapter(SyncProvider):
     """SyncProvider implementation backed by a Stalwart JMAP server."""
+
+    notification_policy = NotificationPolicy(
+        create_item=NotificationCapability.BEST_EFFORT,
+        update_item=NotificationCapability.BEST_EFFORT,
+        delete_item=NotificationCapability.BEST_EFFORT,
+        delete_container=NotificationCapability.BEST_EFFORT,
+    )
 
     def __init__(
         self,
@@ -355,6 +366,7 @@ class JmapCalendarAdapter(SyncProvider):
                 "CalendarEvent/set",
                 {
                     "accountId": self._account_id,
+                    "sendSchedulingMessages": False,
                     "create": {"new1": event},
                 },
                 "c0",
@@ -385,6 +397,7 @@ class JmapCalendarAdapter(SyncProvider):
                 "CalendarEvent/set",
                 {
                     "accountId": self._account_id,
+                    "sendSchedulingMessages": False,
                     "update": {item.provider_id: event},
                 },
                 "u0",
@@ -431,6 +444,7 @@ class JmapCalendarAdapter(SyncProvider):
                 "CalendarEvent/set",
                 {
                     "accountId": self._account_id,
+                    "sendSchedulingMessages": False,
                     "destroy": [item_id],
                 },
                 "d0",

--- a/src/groupware_sync_calendar/cli.py
+++ b/src/groupware_sync_calendar/cli.py
@@ -84,7 +84,7 @@ def sync_cmd(
         m365_token = fw_auth.get_access_token(
             cfg.m365.auth_database_url, cfg.m365.auth_uid, cfg.m365.auth_provider_name,
         )
-    except (ValueError, Exception) as e:
+    except Exception as e:
         typer.echo(f"m365 auth error: {e}", err=True)
         raise typer.Exit(2)
 

--- a/src/groupware_sync_calendar/cli.py
+++ b/src/groupware_sync_calendar/cli.py
@@ -2,8 +2,15 @@
 from __future__ import annotations
 
 import logging
+import sys
 
 import typer
+
+from groupware_sync import auth as fw_auth
+from groupware_sync.config import Config
+from groupware_sync.engine import sync_trees
+from groupware_sync.models import ItemType
+from groupware_sync.state.db import make_session_factory
 
 app = typer.Typer(
     help="Two-way calendar sync between Stalwart and Microsoft 365",
@@ -21,20 +28,40 @@ def _setup_logging(verbose: bool) -> None:
     logging.basicConfig(level=level, format="%(levelname)s %(name)s: %(message)s")
 
 
+def _stdin_isatty() -> bool:
+    """Indirection so tests can stub TTY detection reliably.
+
+    The Click/Typer test runner replaces ``sys.stdin`` with a pipe-backed
+    wrapper inside ``invoke()``, so patching ``sys.stdin.isatty`` from the
+    outside doesn't take effect during the command body. Routing through
+    this module-level function gives tests a stable patch target.
+    """
+    return sys.stdin.isatty()
+
+
 @app.command(name="sync")
 def sync_cmd(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be done without making changes"),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Skip the interactive confirmation and execute immediately. Intended for cron and CI.",
+    ),
 ) -> None:
     """Two-way calendar sync using the tree-based framework engine."""
     _setup_logging(verbose)
     log = logging.getLogger(__name__)
 
-    from groupware_sync import auth as fw_auth
-    from groupware_sync.config import Config
-    from groupware_sync.engine import sync_trees
-    from groupware_sync.models import ItemType
-    from groupware_sync.state.db import make_session_factory
+    # TTY guard: if default mode (not dry-run, not non-interactive) and
+    # stdin isn't a TTY, fail fast before touching any remote state.
+    if not dry_run and not non_interactive and not _stdin_isatty():
+        typer.echo(
+            "interactive mode requires a TTY; pass --non-interactive to auto-execute or --dry-run to preview only",
+            err=True,
+        )
+        raise typer.Exit(2)
+
     from groupware_sync_calendar.adapters.graph_adapter import GraphCalendarAdapter
     from groupware_sync_calendar.adapters.jmap_adapter import JmapCalendarAdapter
     from groupware_sync_calendar.specs import CALENDAR_EVENT_SPEC
@@ -65,9 +92,24 @@ def sync_cmd(
     graph = GraphCalendarAdapter(m365_token, calendar_filter=cfg.m365_calendar)
     sf = make_session_factory(cfg.state_database_url)
 
+    # Choose engine inputs. --dry-run wins silently over --non-interactive.
+    confirm = None
+    if not dry_run and not non_interactive:
+        def confirm(ops, plan_summary):  # noqa: E306
+            return typer.confirm(
+                f"Execute {plan_summary.deleted} deletes, "
+                f"{plan_summary.created} creates, "
+                f"{plan_summary.updated} updates, "
+                f"{plan_summary.containers} container ops?",
+                default=False,
+            )
+
     try:
         with sf() as session:
-            summary = sync_trees(jmap, graph, ItemType.CALENDAR_EVENT, CALENDAR_EVENT_SPEC, session, dry_run=dry_run)
+            summary = sync_trees(
+                jmap, graph, ItemType.CALENDAR_EVENT, CALENDAR_EVENT_SPEC, session,
+                dry_run=dry_run, confirm=confirm,
+            )
     except Exception as e:
         log.error("sync failed: %s", e, exc_info=True)
         typer.echo(f"sync failed: {e}", err=True)
@@ -75,6 +117,10 @@ def sync_cmd(
     finally:
         jmap.close()
         graph.close()
+
+    if summary.aborted:
+        typer.echo("sync aborted by user — no changes made")
+        raise typer.Exit(0)
 
     typer.echo(
         f"sync: containers={summary.containers}"

--- a/src/groupware_sync_contacts/adapters/carddav_adapter.py
+++ b/src/groupware_sync_contacts/adapters/carddav_adapter.py
@@ -23,7 +23,11 @@ from groupware_sync.models import (
     SyncItem,
     SyncNode,
 )
-from groupware_sync.provider import SyncProvider
+from groupware_sync.provider import (
+    NotificationCapability,
+    NotificationPolicy,
+    SyncProvider,
+)
 
 log = logging.getLogger(__name__)
 
@@ -35,6 +39,13 @@ TIMEOUT = 30.0
 
 class CardDavContactAdapter(SyncProvider):
     """SyncProvider implementation backed by a CardDAV server."""
+
+    notification_policy = NotificationPolicy(
+        create_item=NotificationCapability.SUPPRESSED,
+        update_item=NotificationCapability.SUPPRESSED,
+        delete_item=NotificationCapability.SUPPRESSED,
+        delete_container=NotificationCapability.SUPPRESSED,
+    )
 
     def __init__(self, base_url: str, username: str, password: str) -> None:
         self._base_url = base_url.rstrip("/")

--- a/src/groupware_sync_contacts/adapters/graph_adapter.py
+++ b/src/groupware_sync_contacts/adapters/graph_adapter.py
@@ -23,7 +23,11 @@ from groupware_sync.models import (
     SyncItem,
     SyncNode,
 )
-from groupware_sync.provider import SyncProvider
+from groupware_sync.provider import (
+    NotificationCapability,
+    NotificationPolicy,
+    SyncProvider,
+)
 
 log = logging.getLogger(__name__)
 
@@ -42,6 +46,13 @@ _ADDR_FIELDS = {
 
 class GraphContactAdapter(SyncProvider):
     """SyncProvider implementation backed by Microsoft Graph v1.0."""
+
+    notification_policy = NotificationPolicy(
+        create_item=NotificationCapability.SUPPRESSED,
+        update_item=NotificationCapability.SUPPRESSED,
+        delete_item=NotificationCapability.SUPPRESSED,
+        delete_container=NotificationCapability.SUPPRESSED,
+    )
 
     def __init__(self, access_token: str, addressbook_filter: Optional[str] = None) -> None:
         self._client = httpx.Client(

--- a/src/groupware_sync_contacts/adapters/jmap_adapter.py
+++ b/src/groupware_sync_contacts/adapters/jmap_adapter.py
@@ -21,7 +21,11 @@ from groupware_sync.models import (
     SyncItem,
     SyncNode,
 )
-from groupware_sync.provider import SyncProvider
+from groupware_sync.provider import (
+    NotificationCapability,
+    NotificationPolicy,
+    SyncProvider,
+)
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +35,13 @@ USING = ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:contacts"]
 
 class JmapContactAdapter(SyncProvider):
     """SyncProvider implementation backed by a Stalwart JMAP server."""
+
+    notification_policy = NotificationPolicy(
+        create_item=NotificationCapability.SUPPRESSED,
+        update_item=NotificationCapability.SUPPRESSED,
+        delete_item=NotificationCapability.SUPPRESSED,
+        delete_container=NotificationCapability.SUPPRESSED,
+    )
 
     def __init__(
         self, jmap_url: str, access_token: str, addressbook_filter: Optional[str] = None,

--- a/src/groupware_sync_contacts/cli.py
+++ b/src/groupware_sync_contacts/cli.py
@@ -6,8 +6,15 @@ opens the state DB, calls the sync engine, prints a summary, exits.
 from __future__ import annotations
 
 import logging
+import sys
 
 import typer
+
+from groupware_sync import auth as fw_auth
+from groupware_sync.config import Config
+from groupware_sync.engine import sync_trees
+from groupware_sync.models import ItemType
+from groupware_sync.state.db import make_session_factory
 
 app = typer.Typer(
     help="Two-way contacts sync between Stalwart and Microsoft 365",
@@ -28,26 +35,46 @@ def _setup_logging(verbose: bool) -> None:
     )
 
 
+def _stdin_isatty() -> bool:
+    """Indirection so tests can stub TTY detection reliably.
+
+    The Click/Typer test runner replaces ``sys.stdin`` with a pipe-backed
+    wrapper inside ``invoke()``, so patching ``sys.stdin.isatty`` from the
+    outside doesn't take effect during the command body. Routing through
+    this module-level function gives tests a stable patch target.
+    """
+    return sys.stdin.isatty()
+
+
 @app.command(name="sync")
 def sync_cmd(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be done without making changes"),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Skip the interactive confirmation and execute immediately. Intended for cron and CI.",
+    ),
 ) -> None:
-    """Two-way sync using the tree-based framework engine."""
+    """Two-way contacts sync using the tree-based framework engine."""
     _setup_logging(verbose)
     log = logging.getLogger(__name__)
 
-    from groupware_sync import auth as fw_auth
-    from groupware_sync.config import Config as FrameworkConfig
-    from groupware_sync.engine import sync_trees
-    from groupware_sync.models import ItemType
-    from groupware_sync.state.db import make_session_factory as fw_session_factory
+    # TTY guard: if default mode (not dry-run, not non-interactive) and
+    # stdin isn't a TTY, fail fast before touching any remote state.
+    if not dry_run and not non_interactive and not _stdin_isatty():
+        typer.echo(
+            "interactive mode requires a TTY; pass --non-interactive to auto-execute or --dry-run to preview only",
+            err=True,
+        )
+        raise typer.Exit(2)
+
     from groupware_sync_contacts.adapters.graph_adapter import GraphContactAdapter
     from groupware_sync_contacts.adapters.jmap_adapter import JmapContactAdapter
     from groupware_sync_contacts.specs import CONTACT_SPEC
 
     try:
-        cfg = FrameworkConfig.from_env()
+        cfg = Config.from_env()
     except ValueError as e:
         typer.echo(f"config error: {e}", err=True)
         raise typer.Exit(2)
@@ -68,17 +95,32 @@ def sync_cmd(
             cfg.m365.auth_uid,
             cfg.m365.auth_provider_name,
         )
-    except ValueError as e:
+    except (ValueError, Exception) as e:
         typer.echo(f"m365 auth error: {e}", err=True)
         raise typer.Exit(2)
 
     jmap = JmapContactAdapter(cfg.stalwart_jmap_url, stalwart_token, addressbook_filter=cfg.stalwart_addressbook)
     graph = GraphContactAdapter(m365_token, addressbook_filter=cfg.m365_addressbook)
-    sf = fw_session_factory(cfg.state_database_url)
+    sf = make_session_factory(cfg.state_database_url)
+
+    # Choose engine inputs. --dry-run wins silently over --non-interactive.
+    confirm = None
+    if not dry_run and not non_interactive:
+        def confirm(ops, plan_summary):  # noqa: E306
+            return typer.confirm(
+                f"Execute {plan_summary.deleted} deletes, "
+                f"{plan_summary.created} creates, "
+                f"{plan_summary.updated} updates, "
+                f"{plan_summary.containers} container ops?",
+                default=False,
+            )
 
     try:
         with sf() as session:
-            summary = sync_trees(jmap, graph, ItemType.CONTACT, CONTACT_SPEC, session, dry_run=dry_run)
+            summary = sync_trees(
+                jmap, graph, ItemType.CONTACT, CONTACT_SPEC, session,
+                dry_run=dry_run, confirm=confirm,
+            )
     except Exception as e:
         log.error("sync failed: %s", e, exc_info=True)
         typer.echo(f"sync failed: {e}", err=True)
@@ -86,6 +128,10 @@ def sync_cmd(
     finally:
         jmap.close()
         graph.close()
+
+    if summary.aborted:
+        typer.echo("sync aborted by user — no changes made")
+        raise typer.Exit(0)
 
     typer.echo(
         f"sync: containers={summary.containers}"

--- a/src/groupware_sync_contacts/cli.py
+++ b/src/groupware_sync_contacts/cli.py
@@ -95,7 +95,7 @@ def sync_cmd(
             cfg.m365.auth_uid,
             cfg.m365.auth_provider_name,
         )
-    except (ValueError, Exception) as e:
+    except Exception as e:
         typer.echo(f"m365 auth error: {e}", err=True)
         raise typer.Exit(2)
 

--- a/tests/test_caldav_calendar_suppression.py
+++ b/tests/test_caldav_calendar_suppression.py
@@ -1,0 +1,10 @@
+from groupware_sync.provider import NotificationCapability
+from groupware_sync_calendar.adapters.caldav_adapter import CalDavCalendarAdapter
+
+
+def test_caldav_policy_is_unsupported_on_all_ops():
+    p = CalDavCalendarAdapter.notification_policy
+    assert p.create_item is NotificationCapability.UNSUPPORTED
+    assert p.update_item is NotificationCapability.UNSUPPORTED
+    assert p.delete_item is NotificationCapability.UNSUPPORTED
+    assert p.delete_container is NotificationCapability.UNSUPPORTED

--- a/tests/test_cli_calendar.py
+++ b/tests/test_cli_calendar.py
@@ -1,0 +1,101 @@
+"""CLI tests for groupware-sync-calendar: flag matrix and TTY guard."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from groupware_sync.config import Config, ProviderConfig
+from groupware_sync.models import SyncSummary
+from groupware_sync_calendar.cli import app
+
+# click 8.2+ removed the mix_stderr kwarg; stderr is separated by default.
+try:
+    runner = CliRunner(mix_stderr=False)  # type: ignore[call-arg]
+except TypeError:
+    runner = CliRunner()
+
+
+def _fake_cfg() -> Config:
+    prov = ProviderConfig(auth_database_url="x", auth_uid="x", auth_provider_name="x")
+    return Config(
+        sync_type="calendar",
+        stalwart=prov,
+        stalwart_jmap_url="https://stalwart.invalid",
+        stalwart_addressbook=None,
+        stalwart_calendar=None,
+        m365=prov,
+        m365_addressbook=None,
+        m365_calendar=None,
+        state_database_url="sqlite:///:memory:",
+    )
+
+
+@pytest.fixture
+def stub_engine(monkeypatch):
+    """Replace sync_trees and adapter/auth plumbing so the CLI body runs
+    without touching the network or real auth."""
+    calls: dict = {}
+
+    def fake_sync_trees(a, b, item_type, type_spec, session, dry_run=False, confirm=None):
+        calls["dry_run"] = dry_run
+        calls["confirm"] = confirm
+        return SyncSummary()
+
+    monkeypatch.setattr("groupware_sync_calendar.cli.Config.from_env", classmethod(lambda cls: _fake_cfg()))
+    monkeypatch.setattr("groupware_sync_calendar.cli.sync_trees", fake_sync_trees, raising=False)
+    monkeypatch.setattr("groupware_sync_calendar.cli.fw_auth.get_access_token", lambda *a, **kw: "token", raising=False)
+    monkeypatch.setattr("groupware_sync_calendar.adapters.jmap_adapter.JmapCalendarAdapter.__init__", lambda self, *a, **kw: None)
+    monkeypatch.setattr("groupware_sync_calendar.adapters.jmap_adapter.JmapCalendarAdapter.close", lambda self: None)
+    monkeypatch.setattr("groupware_sync_calendar.adapters.graph_adapter.GraphCalendarAdapter.__init__", lambda self, *a, **kw: None)
+    monkeypatch.setattr("groupware_sync_calendar.adapters.graph_adapter.GraphCalendarAdapter.close", lambda self: None)
+    monkeypatch.setattr("groupware_sync.state.db.make_session_factory", lambda url: lambda: _FakeSession(), raising=False)
+    return calls
+
+
+class _FakeSession:
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+    def commit(self): pass
+    def close(self): pass
+
+
+def test_non_tty_without_flags_exits_2(monkeypatch, stub_engine):
+    with patch("groupware_sync_calendar.cli._stdin_isatty", return_value=False):
+        result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 2
+    assert "interactive mode requires a TTY" in result.stderr
+
+
+def test_non_interactive_runs_without_prompt(monkeypatch, stub_engine):
+    with patch("groupware_sync_calendar.cli._stdin_isatty", return_value=False):
+        result = runner.invoke(app, ["sync", "--non-interactive"])
+    assert result.exit_code == 0
+    assert stub_engine["dry_run"] is False
+    assert stub_engine["confirm"] is None
+
+
+def test_dry_run_takes_precedence_over_non_interactive(monkeypatch, stub_engine):
+    with patch("groupware_sync_calendar.cli._stdin_isatty", return_value=False):
+        result = runner.invoke(app, ["sync", "--dry-run", "--non-interactive"])
+    assert result.exit_code == 0
+    assert stub_engine["dry_run"] is True
+    assert stub_engine["confirm"] is None
+
+
+def test_dry_run_alone(monkeypatch, stub_engine):
+    with patch("groupware_sync_calendar.cli._stdin_isatty", return_value=False):
+        result = runner.invoke(app, ["sync", "--dry-run"])
+    assert result.exit_code == 0
+    assert stub_engine["dry_run"] is True
+    assert stub_engine["confirm"] is None
+
+
+def test_default_tty_passes_confirm_callback(monkeypatch, stub_engine):
+    with patch("groupware_sync_calendar.cli._stdin_isatty", return_value=True):
+        result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 0
+    assert stub_engine["dry_run"] is False
+    assert callable(stub_engine["confirm"])

--- a/tests/test_cli_calendar.py
+++ b/tests/test_cli_calendar.py
@@ -1,7 +1,6 @@
 """CLI tests for groupware-sync-calendar: flag matrix and TTY guard."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
@@ -51,15 +50,20 @@ def stub_engine(monkeypatch):
     monkeypatch.setattr("groupware_sync_calendar.adapters.jmap_adapter.JmapCalendarAdapter.close", lambda self: None)
     monkeypatch.setattr("groupware_sync_calendar.adapters.graph_adapter.GraphCalendarAdapter.__init__", lambda self, *a, **kw: None)
     monkeypatch.setattr("groupware_sync_calendar.adapters.graph_adapter.GraphCalendarAdapter.close", lambda self: None)
-    monkeypatch.setattr("groupware_sync.state.db.make_session_factory", lambda url: lambda: _FakeSession(), raising=False)
+    # Patch the symbol on the CLI module (where it's used), not on the source,
+    # because the CLI imports it at module top so the name is bound locally.
+    class _FakeSession:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def commit(self): pass
+        def close(self): pass
+
+    monkeypatch.setattr(
+        "groupware_sync_calendar.cli.make_session_factory",
+        lambda url: lambda: _FakeSession(),
+        raising=False,
+    )
     return calls
-
-
-class _FakeSession:
-    def __enter__(self): return self
-    def __exit__(self, *a): return False
-    def commit(self): pass
-    def close(self): pass
 
 
 def test_non_tty_without_flags_exits_2(monkeypatch, stub_engine):
@@ -99,3 +103,35 @@ def test_default_tty_passes_confirm_callback(monkeypatch, stub_engine):
     assert result.exit_code == 0
     assert stub_engine["dry_run"] is False
     assert callable(stub_engine["confirm"])
+
+
+def test_aborted_summary_exits_zero_with_message(monkeypatch):
+    """When the engine returns summary.aborted=True (user declined the
+    interactive prompt), the CLI prints a friendly message and exits 0."""
+    def fake_sync_trees(a, b, item_type, type_spec, session, dry_run=False, confirm=None):
+        return SyncSummary(aborted=True)
+
+    monkeypatch.setattr("groupware_sync_calendar.cli.Config.from_env", classmethod(lambda cls: _fake_cfg()))
+    monkeypatch.setattr("groupware_sync_calendar.cli.sync_trees", fake_sync_trees, raising=False)
+    monkeypatch.setattr("groupware_sync_calendar.cli.fw_auth.get_access_token", lambda *a, **kw: "token", raising=False)
+    monkeypatch.setattr("groupware_sync_calendar.adapters.jmap_adapter.JmapCalendarAdapter.__init__", lambda self, *a, **kw: None)
+    monkeypatch.setattr("groupware_sync_calendar.adapters.jmap_adapter.JmapCalendarAdapter.close", lambda self: None)
+    monkeypatch.setattr("groupware_sync_calendar.adapters.graph_adapter.GraphCalendarAdapter.__init__", lambda self, *a, **kw: None)
+    monkeypatch.setattr("groupware_sync_calendar.adapters.graph_adapter.GraphCalendarAdapter.close", lambda self: None)
+
+    class _FakeSession:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def commit(self): pass
+        def close(self): pass
+
+    monkeypatch.setattr(
+        "groupware_sync_calendar.cli.make_session_factory",
+        lambda url: lambda: _FakeSession(),
+        raising=False,
+    )
+
+    with patch("groupware_sync_calendar.cli._stdin_isatty", return_value=True):
+        result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 0
+    assert "aborted by user" in result.stdout

--- a/tests/test_cli_contacts.py
+++ b/tests/test_cli_contacts.py
@@ -1,0 +1,137 @@
+"""CLI tests for groupware-sync-contacts: flag matrix and TTY guard."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from groupware_sync.config import Config, ProviderConfig
+from groupware_sync.models import SyncSummary
+from groupware_sync_contacts.cli import app
+
+# click 8.2+ removed the mix_stderr kwarg; stderr is separated by default.
+try:
+    runner = CliRunner(mix_stderr=False)  # type: ignore[call-arg]
+except TypeError:
+    runner = CliRunner()
+
+
+def _fake_cfg() -> Config:
+    prov = ProviderConfig(auth_database_url="x", auth_uid="x", auth_provider_name="x")
+    return Config(
+        sync_type="contacts",
+        stalwart=prov,
+        stalwart_jmap_url="https://stalwart.invalid",
+        stalwart_addressbook=None,
+        stalwart_calendar=None,
+        m365=prov,
+        m365_addressbook=None,
+        m365_calendar=None,
+        state_database_url="sqlite:///:memory:",
+    )
+
+
+@pytest.fixture
+def stub_engine(monkeypatch):
+    """Replace sync_trees and adapter/auth plumbing so the CLI body runs
+    without touching the network or real auth."""
+    calls: dict = {}
+
+    def fake_sync_trees(a, b, item_type, type_spec, session, dry_run=False, confirm=None):
+        calls["dry_run"] = dry_run
+        calls["confirm"] = confirm
+        return SyncSummary()
+
+    monkeypatch.setattr("groupware_sync_contacts.cli.Config.from_env", classmethod(lambda cls: _fake_cfg()))
+    monkeypatch.setattr("groupware_sync_contacts.cli.sync_trees", fake_sync_trees, raising=False)
+    monkeypatch.setattr("groupware_sync_contacts.cli.fw_auth.get_access_token", lambda *a, **kw: "token", raising=False)
+    monkeypatch.setattr("groupware_sync_contacts.adapters.jmap_adapter.JmapContactAdapter.__init__", lambda self, *a, **kw: None)
+    monkeypatch.setattr("groupware_sync_contacts.adapters.jmap_adapter.JmapContactAdapter.close", lambda self: None)
+    monkeypatch.setattr("groupware_sync_contacts.adapters.graph_adapter.GraphContactAdapter.__init__", lambda self, *a, **kw: None)
+    monkeypatch.setattr("groupware_sync_contacts.adapters.graph_adapter.GraphContactAdapter.close", lambda self: None)
+    # Patch the symbol on the CLI module (where it's used), not on the source,
+    # because the CLI imports it at module top so the name is bound locally.
+    class _FakeSession:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def commit(self): pass
+        def close(self): pass
+
+    monkeypatch.setattr(
+        "groupware_sync_contacts.cli.make_session_factory",
+        lambda url: lambda: _FakeSession(),
+        raising=False,
+    )
+    return calls
+
+
+def test_non_tty_without_flags_exits_2(monkeypatch, stub_engine):
+    with patch("groupware_sync_contacts.cli._stdin_isatty", return_value=False):
+        result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 2
+    assert "interactive mode requires a TTY" in result.stderr
+
+
+def test_non_interactive_runs_without_prompt(monkeypatch, stub_engine):
+    with patch("groupware_sync_contacts.cli._stdin_isatty", return_value=False):
+        result = runner.invoke(app, ["sync", "--non-interactive"])
+    assert result.exit_code == 0
+    assert stub_engine["dry_run"] is False
+    assert stub_engine["confirm"] is None
+
+
+def test_dry_run_takes_precedence_over_non_interactive(monkeypatch, stub_engine):
+    with patch("groupware_sync_contacts.cli._stdin_isatty", return_value=False):
+        result = runner.invoke(app, ["sync", "--dry-run", "--non-interactive"])
+    assert result.exit_code == 0
+    assert stub_engine["dry_run"] is True
+    assert stub_engine["confirm"] is None
+
+
+def test_dry_run_alone(monkeypatch, stub_engine):
+    with patch("groupware_sync_contacts.cli._stdin_isatty", return_value=False):
+        result = runner.invoke(app, ["sync", "--dry-run"])
+    assert result.exit_code == 0
+    assert stub_engine["dry_run"] is True
+    assert stub_engine["confirm"] is None
+
+
+def test_default_tty_passes_confirm_callback(monkeypatch, stub_engine):
+    with patch("groupware_sync_contacts.cli._stdin_isatty", return_value=True):
+        result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 0
+    assert stub_engine["dry_run"] is False
+    assert callable(stub_engine["confirm"])
+
+
+def test_aborted_summary_exits_zero_with_message(monkeypatch):
+    """When the engine returns summary.aborted=True (user declined the
+    interactive prompt), the CLI prints a friendly message and exits 0."""
+    def fake_sync_trees(a, b, item_type, type_spec, session, dry_run=False, confirm=None):
+        return SyncSummary(aborted=True)
+
+    monkeypatch.setattr("groupware_sync_contacts.cli.Config.from_env", classmethod(lambda cls: _fake_cfg()))
+    monkeypatch.setattr("groupware_sync_contacts.cli.sync_trees", fake_sync_trees, raising=False)
+    monkeypatch.setattr("groupware_sync_contacts.cli.fw_auth.get_access_token", lambda *a, **kw: "token", raising=False)
+    monkeypatch.setattr("groupware_sync_contacts.adapters.jmap_adapter.JmapContactAdapter.__init__", lambda self, *a, **kw: None)
+    monkeypatch.setattr("groupware_sync_contacts.adapters.jmap_adapter.JmapContactAdapter.close", lambda self: None)
+    monkeypatch.setattr("groupware_sync_contacts.adapters.graph_adapter.GraphContactAdapter.__init__", lambda self, *a, **kw: None)
+    monkeypatch.setattr("groupware_sync_contacts.adapters.graph_adapter.GraphContactAdapter.close", lambda self: None)
+
+    class _FakeSession:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def commit(self): pass
+        def close(self): pass
+
+    monkeypatch.setattr(
+        "groupware_sync_contacts.cli.make_session_factory",
+        lambda url: lambda: _FakeSession(),
+        raising=False,
+    )
+
+    with patch("groupware_sync_contacts.cli._stdin_isatty", return_value=True):
+        result = runner.invoke(app, ["sync"])
+    assert result.exit_code == 0
+    assert "aborted by user" in result.stdout

--- a/tests/test_contacts_notification_policy.py
+++ b/tests/test_contacts_notification_policy.py
@@ -1,0 +1,15 @@
+from groupware_sync.provider import NotificationCapability
+from groupware_sync_contacts.adapters.carddav_adapter import CardDavContactAdapter
+from groupware_sync_contacts.adapters.graph_adapter import GraphContactAdapter
+from groupware_sync_contacts.adapters.jmap_adapter import JmapContactAdapter
+
+ALL_ADAPTERS = [CardDavContactAdapter, GraphContactAdapter, JmapContactAdapter]
+
+
+def test_all_contacts_adapters_declare_suppressed():
+    for cls in ALL_ADAPTERS:
+        p = cls.notification_policy
+        for field in ("create_item", "update_item", "delete_item", "delete_container"):
+            assert getattr(p, field) is NotificationCapability.SUPPRESSED, (
+                f"{cls.__name__}.notification_policy.{field} must be SUPPRESSED"
+            )

--- a/tests/test_engine_interactive.py
+++ b/tests/test_engine_interactive.py
@@ -141,19 +141,37 @@ def _basic_spec() -> TypeSpec:
 
 
 def test_confirm_true_runs_writes(session):
-    a = _fake("a", NotificationCapability.SUPPRESSED)
-    b = _fake("b", NotificationCapability.SUPPRESSED)
+    """Non-empty plan + confirm returning True must invoke the callback AND
+    execute phase 4 writes on the target side."""
+    # Both sides have a container with the same id ("c1"); leaf exists only
+    # on b, so the plan is a single CREATE_ITEM on a (no container create).
+    leaf = SyncNode("x1", "x1", NodeType.LEAF, fingerprint="fp", item_type=ItemType.CALENDAR_EVENT)
+    a_container = SyncNode("c1", "c1", NodeType.CONTAINER, children=[])
+    b_container = SyncNode("c1", "c1", NodeType.CONTAINER, children=[leaf])
+    a_tree = SyncNode("root", "root", NodeType.CONTAINER, children=[a_container])
+    a_tree.compute_merkle()
+    b_tree = SyncNode("root", "root", NodeType.CONTAINER, children=[b_container])
+    b_tree.compute_merkle()
+
+    a = FakeProvider("a", _policy(NotificationCapability.SUPPRESSED), a_tree)
+    b = FakeProvider("b", _policy(NotificationCapability.SUPPRESSED), b_tree)
+
+    # The FakeProvider's default get_items returns []; populate b so the
+    # engine's create path can fetch the source item.
+    from unittest.mock import patch
+    fetched_item = SyncItem(provider_id="x1", item_type=ItemType.CALENDAR_EVENT, fields={"uid": "u1"})
     called: list[bool] = []
 
     def confirm(ops, summary):
         called.append(True)
         return True
 
-    summary = sync_trees(a, b, ItemType.CALENDAR_EVENT, _basic_spec(), session, confirm=confirm)
-    # Empty-plan short-circuit fires here (both trees are empty) — confirm is
-    # not called and the summary is aborted=False with all zeros.
-    assert called == []
+    with patch.object(FakeProvider, "get_items", return_value=[fetched_item]):
+        summary = sync_trees(a, b, ItemType.CALENDAR_EVENT, _basic_spec(), session, confirm=confirm)
+    assert called == [True]
     assert summary.aborted is False
+    # The planned op was a CREATE_ITEM on side a; confirm that phase 4 ran.
+    assert len(a.create_item_calls) == 1
 
 
 def test_confirm_false_sets_aborted_and_skips_writes(session):

--- a/tests/test_engine_interactive.py
+++ b/tests/test_engine_interactive.py
@@ -1,0 +1,124 @@
+"""Tests for the interactive sync flow: plan formatting and the confirm
+callback branch of sync_trees."""
+from __future__ import annotations
+
+from groupware_sync.engine import _format_plan
+from groupware_sync.models import (
+    ItemType,
+    NodeType,
+    OpType,
+    SyncItem,
+    SyncNode,
+    SyncOp,
+    TypeSpec,
+)
+from groupware_sync.provider import (
+    NotificationCapability,
+    NotificationPolicy,
+    SyncProvider,
+)
+
+
+def _policy(cap: NotificationCapability) -> NotificationPolicy:
+    return NotificationPolicy(
+        create_item=cap, update_item=cap, delete_item=cap, delete_container=cap,
+    )
+
+
+class FakeProvider(SyncProvider):
+    """Minimal in-memory SyncProvider for engine tests."""
+
+    def __init__(self, name: str, policy: NotificationPolicy, tree: SyncNode):
+        self._name = name
+        self.notification_policy = policy
+        self._tree = tree
+        self.create_item_calls: list[tuple[str, SyncItem]] = []
+        self.update_item_calls: list[tuple[str, SyncItem]] = []
+        self.delete_item_calls: list[tuple[str, str]] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def build_tree(self, item_type, known_states=None):  # noqa: ANN001
+        return self._tree
+
+    def get_items(self, container_id, ids):  # noqa: ANN001
+        return []
+
+    def create_container(self, name, parent_id=None):  # noqa: ANN001
+        return f"c-{name}"
+
+    def delete_container(self, container_id):  # noqa: ANN001
+        return None
+
+    def create_item(self, container_id, item):  # noqa: ANN001
+        self.create_item_calls.append((container_id, item))
+        return (f"srv-{len(self.create_item_calls)}", "fp")
+
+    def update_item(self, container_id, item):  # noqa: ANN001
+        self.update_item_calls.append((container_id, item))
+        return "fp"
+
+    def delete_item(self, container_id, item_id):  # noqa: ANN001
+        self.delete_item_calls.append((container_id, item_id))
+
+
+def _fake(name: str, cap: NotificationCapability) -> FakeProvider:
+    tree = SyncNode(f"root-{name}", f"root-{name}", NodeType.CONTAINER, children=[])
+    tree.compute_merkle()
+    return FakeProvider(name, _policy(cap), tree)
+
+
+def test_format_plan_emits_one_line_per_op():
+    a = _fake("a", NotificationCapability.SUPPRESSED)
+    b = _fake("b", NotificationCapability.SUPPRESSED)
+    ops = [
+        SyncOp(op_type=OpType.CREATE_ITEM, target_side="b", node_id="x1", container_id_b="cb"),
+        SyncOp(op_type=OpType.DELETE_ITEM, target_side="b", node_id="x2", container_id_b="cb"),
+    ]
+    lines = _format_plan(ops, a, b)
+    assert len(lines) == 2
+    assert lines[0].startswith("PLAN CREATE_ITEM")
+    assert lines[1].startswith("PLAN DELETE_ITEM")
+    assert "on b" in lines[0]
+
+
+def test_format_plan_no_annotation_when_suppressed():
+    a = _fake("a", NotificationCapability.SUPPRESSED)
+    b = _fake("b", NotificationCapability.SUPPRESSED)
+    ops = [SyncOp(op_type=OpType.DELETE_ITEM, target_side="b", node_id="x", container_id_b="cb")]
+    lines = _format_plan(ops, a, b)
+    assert "[!]" not in lines[0]
+
+
+def test_format_plan_best_effort_annotation():
+    a = _fake("a", NotificationCapability.SUPPRESSED)
+    b = _fake("b", NotificationCapability.BEST_EFFORT)
+    ops = [SyncOp(op_type=OpType.DELETE_ITEM, target_side="b", node_id="x", container_id_b="cb")]
+    lines = _format_plan(ops, a, b)
+    assert "[!] notifications best-effort" in lines[0]
+
+
+def test_format_plan_unsupported_annotation():
+    a = _fake("a", NotificationCapability.SUPPRESSED)
+    b = _fake("b", NotificationCapability.UNSUPPORTED)
+    ops = [SyncOp(op_type=OpType.DELETE_CONTAINER, target_side="b", node_id="x", container_id_b="cb")]
+    lines = _format_plan(ops, a, b)
+    assert "[!] notifications unsupported" in lines[0]
+
+
+def test_format_plan_merge_annotates_if_either_side_not_suppressed():
+    a = _fake("a", NotificationCapability.BEST_EFFORT)
+    b = _fake("b", NotificationCapability.SUPPRESSED)
+    ops = [SyncOp(op_type=OpType.MERGE_ITEM, target_side="both", node_id="x", paired_node_id="y")]
+    lines = _format_plan(ops, a, b)
+    assert "[!] notifications best-effort" in lines[0]
+
+
+def test_format_plan_skip_subtree_never_annotated():
+    a = _fake("a", NotificationCapability.UNSUPPORTED)
+    b = _fake("b", NotificationCapability.UNSUPPORTED)
+    ops = [SyncOp(op_type=OpType.SKIP_SUBTREE, target_side="b", node_id="x")]
+    lines = _format_plan(ops, a, b)
+    assert "[!]" not in lines[0]

--- a/tests/test_engine_interactive.py
+++ b/tests/test_engine_interactive.py
@@ -233,6 +233,22 @@ def test_empty_plan_skips_confirm(session):
     assert summary.aborted is False
 
 
+def test_skip_only_plan_does_not_prompt(session):
+    """A plan that contains only SKIP_SUBTREE ops (subtrees matched stored
+    state, nothing to do) must NOT prompt the user. Populating the summary's
+    skipped count and returning cleanly is the correct behavior."""
+    from groupware_sync.engine import _has_write_op
+
+    skip_op = SyncOp(op_type=OpType.SKIP_SUBTREE, target_side="a", node_id="cal-1")
+    both_gone = SyncOp(op_type=OpType.DELETE_ITEM, target_side="both", node_id="x", paired_node_id="y")
+    assert _has_write_op([skip_op]) is False
+    assert _has_write_op([both_gone]) is False
+    assert _has_write_op([skip_op, both_gone]) is False
+
+    write_op = SyncOp(op_type=OpType.CREATE_ITEM, target_side="b", node_id="x1", container_id_b="cb")
+    assert _has_write_op([skip_op, write_op]) is True
+
+
 def test_confirm_keyboard_interrupt_propagates(session):
     # Build a non-empty plan (leaf exists only on provider_b, so engine plans a create on a).
     leaf = SyncNode("x1", "x1", NodeType.LEAF, fingerprint="fp", item_type=ItemType.CALENDAR_EVENT)

--- a/tests/test_engine_interactive.py
+++ b/tests/test_engine_interactive.py
@@ -2,7 +2,9 @@
 callback branch of sync_trees."""
 from __future__ import annotations
 
-from groupware_sync.engine import _format_plan
+import pytest
+
+from groupware_sync.engine import _format_plan, sync_trees
 from groupware_sync.models import (
     ItemType,
     NodeType,
@@ -17,6 +19,7 @@ from groupware_sync.provider import (
     NotificationPolicy,
     SyncProvider,
 )
+from groupware_sync.state.db import make_session_factory
 
 
 def _policy(cap: NotificationCapability) -> NotificationPolicy:
@@ -122,3 +125,113 @@ def test_format_plan_skip_subtree_never_annotated():
     ops = [SyncOp(op_type=OpType.SKIP_SUBTREE, target_side="b", node_id="x")]
     lines = _format_plan(ops, a, b)
     assert "[!]" not in lines[0]
+
+
+@pytest.fixture
+def session(tmp_path):
+    db_path = tmp_path / "t.db"
+    sf = make_session_factory(f"sqlite:///{db_path}")
+    s = sf()
+    yield s
+    s.close()
+
+
+def _basic_spec() -> TypeSpec:
+    return TypeSpec(item_type=ItemType.CALENDAR_EVENT, fields=[], identity_fields=[])
+
+
+def test_confirm_true_runs_writes(session):
+    a = _fake("a", NotificationCapability.SUPPRESSED)
+    b = _fake("b", NotificationCapability.SUPPRESSED)
+    called: list[bool] = []
+
+    def confirm(ops, summary):
+        called.append(True)
+        return True
+
+    summary = sync_trees(a, b, ItemType.CALENDAR_EVENT, _basic_spec(), session, confirm=confirm)
+    # Empty-plan short-circuit fires here (both trees are empty) — confirm is
+    # not called and the summary is aborted=False with all zeros.
+    assert called == []
+    assert summary.aborted is False
+
+
+def test_confirm_false_sets_aborted_and_skips_writes(session):
+    # Build non-empty trees so we can exercise the confirm branch.
+    leaf = SyncNode("x1", "x1", NodeType.LEAF, fingerprint="fp", item_type=ItemType.CALENDAR_EVENT)
+    container = SyncNode("cb", "cb", NodeType.CONTAINER, children=[leaf])
+    a_tree = SyncNode("root-a", "root-a", NodeType.CONTAINER, children=[])
+    a_tree.compute_merkle()
+    b_tree = SyncNode("root-b", "root-b", NodeType.CONTAINER, children=[container])
+    b_tree.compute_merkle()
+
+    a = FakeProvider("a", _policy(NotificationCapability.SUPPRESSED), a_tree)
+    b = FakeProvider("b", _policy(NotificationCapability.SUPPRESSED), b_tree)
+
+    def confirm(ops, summary):
+        return False
+
+    summary = sync_trees(a, b, ItemType.CALENDAR_EVENT, _basic_spec(), session, confirm=confirm)
+    assert summary.aborted is True
+    # No writes happened on either side.
+    assert a.create_item_calls == [] and b.create_item_calls == []
+    assert a.delete_item_calls == [] and b.delete_item_calls == []
+
+
+def test_confirm_none_runs_legacy_path(session):
+    a = _fake("a", NotificationCapability.SUPPRESSED)
+    b = _fake("b", NotificationCapability.SUPPRESSED)
+    summary = sync_trees(a, b, ItemType.CALENDAR_EVENT, _basic_spec(), session, confirm=None)
+    assert summary.aborted is False
+
+
+def test_dry_run_ignores_confirm(session):
+    a = _fake("a", NotificationCapability.SUPPRESSED)
+    b = _fake("b", NotificationCapability.SUPPRESSED)
+    called: list[bool] = []
+
+    def confirm(ops, summary):
+        called.append(True)
+        return True
+
+    summary = sync_trees(
+        a, b, ItemType.CALENDAR_EVENT, _basic_spec(), session, dry_run=True, confirm=confirm
+    )
+    assert called == []
+    assert summary.aborted is False
+
+
+def test_empty_plan_skips_confirm(session):
+    a = _fake("a", NotificationCapability.SUPPRESSED)
+    b = _fake("b", NotificationCapability.SUPPRESSED)
+    called: list[bool] = []
+
+    def confirm(ops, summary):
+        called.append(True)
+        return True
+
+    summary = sync_trees(a, b, ItemType.CALENDAR_EVENT, _basic_spec(), session, confirm=confirm)
+    assert called == []
+    assert summary.aborted is False
+
+
+def test_confirm_keyboard_interrupt_propagates(session):
+    # Build a non-empty plan (leaf exists only on provider_b, so engine plans a create on a).
+    leaf = SyncNode("x1", "x1", NodeType.LEAF, fingerprint="fp", item_type=ItemType.CALENDAR_EVENT)
+    container = SyncNode("cb", "cb", NodeType.CONTAINER, children=[leaf])
+    a_tree = SyncNode("root-a", "root-a", NodeType.CONTAINER, children=[])
+    a_tree.compute_merkle()
+    b_tree = SyncNode("root-b", "root-b", NodeType.CONTAINER, children=[container])
+    b_tree.compute_merkle()
+
+    a = FakeProvider("a", _policy(NotificationCapability.SUPPRESSED), a_tree)
+    b = FakeProvider("b", _policy(NotificationCapability.SUPPRESSED), b_tree)
+
+    def confirm(ops, summary):
+        raise KeyboardInterrupt()
+
+    with pytest.raises(KeyboardInterrupt):
+        sync_trees(a, b, ItemType.CALENDAR_EVENT, _basic_spec(), session, confirm=confirm)
+
+    # No writes happened — prompt raised before phase 4.
+    assert a.create_item_calls == [] and b.delete_item_calls == []

--- a/tests/test_graph_calendar_suppression.py
+++ b/tests/test_graph_calendar_suppression.py
@@ -1,0 +1,99 @@
+"""Verify GraphCalendarAdapter declares its notification policy and sends
+the Prefer: outlook.send-notifications=false header on every write."""
+from __future__ import annotations
+
+import httpx
+
+from groupware_sync.models import ItemType, SyncItem
+from groupware_sync.provider import NotificationCapability
+from groupware_sync_calendar.adapters.graph_adapter import (
+    GRAPH_BASE,
+    GraphCalendarAdapter,
+)
+
+PREFER_HEADER = "outlook.send-notifications=false"
+
+
+def _adapter_with_transport(transport: httpx.MockTransport) -> GraphCalendarAdapter:
+    adapter = GraphCalendarAdapter("token")
+    adapter._client = httpx.Client(
+        base_url=GRAPH_BASE,
+        headers={"Authorization": "Bearer token"},
+        transport=transport,
+        timeout=5.0,
+    )
+    return adapter
+
+
+def test_policy_is_best_effort_on_all_ops():
+    p = GraphCalendarAdapter.notification_policy
+    assert p.create_item is NotificationCapability.BEST_EFFORT
+    assert p.update_item is NotificationCapability.BEST_EFFORT
+    assert p.delete_item is NotificationCapability.BEST_EFFORT
+    assert p.delete_container is NotificationCapability.BEST_EFFORT
+
+
+def test_create_item_sends_prefer_header():
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(201, json={"id": "new-id", "lastModifiedDateTime": "2026-04-17T00:00:00Z"})
+
+    adapter = _adapter_with_transport(httpx.MockTransport(handler))
+    item = SyncItem(
+        provider_id="",
+        item_type=ItemType.CALENDAR_EVENT,
+        fields={"summary": "x", "uid": "u1", "dtstart_utc": "2026-06-01T10:00:00Z", "dtend_utc": "2026-06-01T11:00:00Z", "dtstart_tz": "UTC", "dtend_tz": "UTC", "all_day": False},
+    )
+    adapter.create_item("calid", item)
+    assert len(captured) == 1
+    prefer = captured[0].headers.get("Prefer", "")
+    assert PREFER_HEADER in prefer
+
+
+def test_update_item_sends_prefer_header():
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"lastModifiedDateTime": "2026-04-17T00:00:00Z"})
+
+    adapter = _adapter_with_transport(httpx.MockTransport(handler))
+    item = SyncItem(
+        provider_id="ev1",
+        item_type=ItemType.CALENDAR_EVENT,
+        fields={"summary": "y", "uid": "u2", "dtstart_utc": "2026-06-01T10:00:00Z", "dtend_utc": "2026-06-01T11:00:00Z", "dtstart_tz": "UTC", "dtend_tz": "UTC", "all_day": False},
+    )
+    adapter.update_item("calid", item)
+    assert len(captured) == 1
+    prefer = captured[0].headers.get("Prefer", "")
+    assert PREFER_HEADER in prefer
+
+
+def test_delete_item_sends_prefer_header():
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(204)
+
+    adapter = _adapter_with_transport(httpx.MockTransport(handler))
+    adapter.delete_item("calid", "ev1")
+    assert len(captured) == 1
+    prefer = captured[0].headers.get("Prefer", "")
+    assert PREFER_HEADER in prefer
+
+
+def test_read_requests_do_not_send_prefer_header():
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"value": []})
+
+    adapter = _adapter_with_transport(httpx.MockTransport(handler))
+    adapter._request("GET", "/me/calendars")
+    assert len(captured) == 1
+    prefer = captured[0].headers.get("Prefer", "")
+    assert PREFER_HEADER not in prefer

--- a/tests/test_jmap_calendar_suppression.py
+++ b/tests/test_jmap_calendar_suppression.py
@@ -1,0 +1,79 @@
+"""Verify JmapCalendarAdapter declares its notification policy and sends
+sendSchedulingMessages: false on every CalendarEvent/set call."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from groupware_sync.models import ItemType, SyncItem
+from groupware_sync.provider import NotificationCapability
+from groupware_sync_calendar.adapters.jmap_adapter import JmapCalendarAdapter
+
+
+def _make_adapter() -> JmapCalendarAdapter:
+    # URL and token are irrelevant — we stub _call.
+    adapter = JmapCalendarAdapter("https://example.invalid/jmap", "token")
+    adapter._api_url = "https://example.invalid/jmap/api"
+    adapter._account_id = "u0"
+    return adapter
+
+
+def test_policy_is_best_effort_on_all_ops():
+    p = JmapCalendarAdapter.notification_policy
+    assert p.create_item is NotificationCapability.BEST_EFFORT
+    assert p.update_item is NotificationCapability.BEST_EFFORT
+    assert p.delete_item is NotificationCapability.BEST_EFFORT
+    assert p.delete_container is NotificationCapability.BEST_EFFORT
+
+
+def _capture_call(calls: list[list]) -> callable:
+    """Replace _call so tests can inspect request envelopes."""
+    def fake_call(self, methods):  # noqa: ANN001
+        calls.append(methods)
+        out = []
+        for m in methods:
+            name = m[0]
+            args = m[1]
+            cid = m[2]
+            if "create" in args:
+                out.append([name, {"created": {k: {"id": f"srv-{k}", "updated": "2026"} for k in args["create"]}}, cid])
+            elif "update" in args:
+                out.append([name, {"updated": {k: None for k in args["update"]}}, cid])
+            elif "destroy" in args:
+                out.append([name, {"destroyed": list(args["destroy"])}, cid])
+        return out
+    return fake_call
+
+
+def test_create_item_sends_send_scheduling_messages_false():
+    adapter = _make_adapter()
+    calls: list[list] = []
+    item = SyncItem(provider_id="", item_type=ItemType.CALENDAR_EVENT, fields={"summary": "x", "uid": "u1"})
+    with patch.object(JmapCalendarAdapter, "_call", _capture_call(calls)):
+        adapter.create_item("cal1", item)
+    assert len(calls) == 1
+    method = calls[0][0]
+    assert method[0] == "CalendarEvent/set"
+    assert method[1].get("sendSchedulingMessages") is False
+
+
+def test_update_item_sends_send_scheduling_messages_false():
+    adapter = _make_adapter()
+    calls: list[list] = []
+    item = SyncItem(provider_id="ev1", item_type=ItemType.CALENDAR_EVENT, fields={"summary": "y", "uid": "u2"})
+    with patch.object(JmapCalendarAdapter, "_call", _capture_call(calls)):
+        with patch.object(JmapCalendarAdapter, "_get_item_fingerprint", return_value="fp"):
+            adapter.update_item("cal1", item)
+    set_call = calls[0][0]
+    assert set_call[0] == "CalendarEvent/set"
+    assert set_call[1].get("sendSchedulingMessages") is False
+
+
+def test_delete_item_sends_send_scheduling_messages_false():
+    adapter = _make_adapter()
+    calls: list[list] = []
+    with patch.object(JmapCalendarAdapter, "_call", _capture_call(calls)):
+        adapter.delete_item("cal1", "ev1")
+    assert len(calls) == 1
+    method = calls[0][0]
+    assert method[0] == "CalendarEvent/set"
+    assert method[1].get("sendSchedulingMessages") is False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -107,3 +107,26 @@ def test_sync_item_round_trip_with_datetime():
     d = item.to_dict()
     item2 = SyncItem.from_dict(d)
     assert item2.updated_at == ts
+
+
+from groupware_sync.provider import (
+    NotificationCapability,
+    NotificationPolicy,
+)
+
+
+def test_notification_capability_values():
+    assert NotificationCapability.SUPPRESSED.value == "suppressed"
+    assert NotificationCapability.BEST_EFFORT.value == "best-effort"
+    assert NotificationCapability.UNSUPPORTED.value == "unsupported"
+
+
+def test_notification_policy_construction():
+    policy = NotificationPolicy(
+        create_item=NotificationCapability.SUPPRESSED,
+        update_item=NotificationCapability.BEST_EFFORT,
+        delete_item=NotificationCapability.UNSUPPORTED,
+        delete_container=NotificationCapability.SUPPRESSED,
+    )
+    assert policy.create_item is NotificationCapability.SUPPRESSED
+    assert policy.delete_item is NotificationCapability.UNSUPPORTED

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -130,3 +130,16 @@ def test_notification_policy_construction():
     )
     assert policy.create_item is NotificationCapability.SUPPRESSED
     assert policy.delete_item is NotificationCapability.UNSUPPORTED
+
+
+from groupware_sync.models import SyncSummary
+
+
+def test_sync_summary_aborted_defaults_false():
+    s = SyncSummary()
+    assert s.aborted is False
+
+
+def test_sync_summary_aborted_settable():
+    s = SyncSummary(aborted=True)
+    assert s.aborted is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,11 @@ from groupware_sync.models import (
     NodeType,
     SyncItem,
     SyncNode,
+    SyncSummary,
+)
+from groupware_sync.provider import (
+    NotificationCapability,
+    NotificationPolicy,
 )
 
 
@@ -109,12 +114,6 @@ def test_sync_item_round_trip_with_datetime():
     assert item2.updated_at == ts
 
 
-from groupware_sync.provider import (
-    NotificationCapability,
-    NotificationPolicy,
-)
-
-
 def test_notification_capability_values():
     assert NotificationCapability.SUPPRESSED.value == "suppressed"
     assert NotificationCapability.BEST_EFFORT.value == "best-effort"
@@ -130,9 +129,6 @@ def test_notification_policy_construction():
     )
     assert policy.create_item is NotificationCapability.SUPPRESSED
     assert policy.delete_item is NotificationCapability.UNSUPPORTED
-
-
-from groupware_sync.models import SyncSummary
 
 
 def test_sync_summary_aborted_defaults_false():


### PR DESCRIPTION
## Summary

Response to the 2026-04-16 calendar mass-delete incident, where a silent JMAP adapter bug cascaded into hundreds of M365 event deletes with attendee cancellation emails.

- **Interactive default**: both `groupware-sync-calendar sync` and `groupware-sync-contacts sync` now print the plan and prompt `[y/N]` before writing. `--non-interactive` preserves auto-execute for cron; non-TTY without that flag fails fast with exit 2. `--dry-run` unchanged and wins silently over `--non-interactive`.
- **Notification suppression**: every adapter write attempts to suppress attendee notifications — JMAP adds `sendSchedulingMessages: false`, Graph adds `Prefer: outlook.send-notifications=false` to POST/PATCH/DELETE. Each adapter declares a `notification_policy` (SUPPRESSED / BEST_EFFORT / UNSUPPORTED per op type); the plan output annotates risky ops with `[!] notifications best-effort/unsupported`.
- **JMAP `notCreated` fix**: the incident's root cause — adapter now raises `ValueError` instead of silently `KeyError`-ing when Stalwart rejects a create.

Spec: `~/.claude/projects/-home-micke-sources-groupware-sync/specs/2026-04-17-interactive-sync-mode-design.md`
Plan: `~/.claude/projects/-home-micke-sources-groupware-sync/plans/2026-04-17-interactive-sync-mode-plan.md`

## Structure

15 commits, landed in 11 plan tasks (TDD throughout):

- `c4a1ab3` fix(jmap): check notCreated in CalendarEvent/set response
- `4a90e3c` feat(provider): declare NotificationCapability and NotificationPolicy
- `51ed3cf` feat(models): add aborted flag to SyncSummary
- `185e5f0` feat(jmap-calendar): suppress scheduling messages, declare policy
- `2b0a833` feat(graph-calendar): suppress attendee notifications on writes
- `2ab8cfa` feat(caldav): declare UNSUPPORTED notification policy
- `9bec403` feat(contacts): declare SUPPRESSED notification policy
- `4803b13` refactor(engine): extract _format_plan with suppression annotations
- `019073f` feat(engine): add confirm callback for interactive sync
- `ae2c340` feat(calendar-cli): interactive default, --non-interactive opt-in
- `36e422d` feat(contacts-cli): interactive default, --non-interactive opt-in
- Plus four small cleanup/review-fix commits (`6f8620c`, `68c131b`, `11af0a6`, `6045b67`).

## Test plan

- [ ] `python3 -m pytest tests --ignore=tests/e2e` — expect ~97 passed (or ~90 if `vobject` is missing; two files require it for collection)
- [ ] Run `groupware-sync-calendar sync --dry-run` against staging — plan output uses `PLAN ...` format with `[!]` annotations where BEST_EFFORT
- [ ] Run `echo "" | groupware-sync-calendar sync` — exit 2, stderr says "interactive mode requires a TTY", no network calls
- [ ] Run `groupware-sync-calendar sync` in a TTY with a test attendee on M365, answer `n` — verify no writes and no emails
- [ ] Repeat, answer `y` — verify writes apply, still no attendee emails (regression test for 2026-04-16)
- [ ] If suppression confirmed silent on a given op type, upgrade the adapter's `notification_policy` field from `BEST_EFFORT` to `SUPPRESSED` (manual verification step in the plan, Task 11)

## Out of scope

- Delete thresholds / create-error thresholds (interactive prompt is the safety gate)
- JSON/structured plan output (text only for now)
- CalDAV `Schedule-Reply: F` iTIP suppression (CalDAV declared UNSUPPORTED; adapter isn't wired to any CLI yet)
- Recovery tooling for the 2026-04-16 incident