### PR TITLE
incident response: identity-based pairing + Stalwart adapter fixes

### DIFF
--- a/src/groupware_sync/engine.py
+++ b/src/groupware_sync/engine.py
@@ -7,6 +7,7 @@ deletes) while maintaining the state DB.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import logging
 import sys
 from collections import defaultdict
@@ -590,6 +591,17 @@ def _merge_one(
 # ---------------------------------------------------------------------------
 
 
+def _legacy_identity_key(*parts: str) -> str:
+    """Deterministic 64-hex fallback key for leaves without a real identity.
+
+    Kept distinct from real identity-keyed mappings by namespacing with
+    'legacy' inside the hash input. Fits the ItemMapping.identity_key
+    VARCHAR(64) column on MySQL/Postgres.
+    """
+    raw = "|".join(("legacy", *parts))
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
 def _execute_creates(
     create_ops: list[SyncOp],
     provider_a: SyncProvider,
@@ -722,7 +734,9 @@ def _execute_creates(
             a_id,
             b_id,
             identity_key=(
-                op_a.identity_key or op_b.identity_key or f"legacy:{a_id}"
+                op_a.identity_key
+                or op_b.identity_key
+                or _legacy_identity_key(a_id, b_id)
             ),
             fingerprint_a=new_fp_a,
             fingerprint_b=new_fp_b,
@@ -763,7 +777,7 @@ def _execute_creates(
             pair.id,
             a_id,
             new_b_id,
-            identity_key=op.identity_key or f"legacy:{a_id}",
+            identity_key=op.identity_key or _legacy_identity_key(a_id, new_b_id),
             fingerprint_a=item_a.fingerprint,
             fingerprint_b=new_b_fp,
         )
@@ -802,7 +816,7 @@ def _execute_creates(
             pair.id,
             new_a_id,
             b_id,
-            identity_key=op.identity_key or f"legacy:{b_id}",
+            identity_key=op.identity_key or _legacy_identity_key(new_a_id, b_id),
             fingerprint_a=new_a_fp,
             fingerprint_b=item_b.fingerprint,
         )

--- a/src/groupware_sync/engine.py
+++ b/src/groupware_sync/engine.py
@@ -718,6 +718,9 @@ def _execute_creates(
             pair.id,
             a_id,
             b_id,
+            # Placeholder: IP-9 wires the real identity_key from SyncOp.
+            # Using a_id keeps uniqueness within a pair.
+            identity_key=f"legacy:{a_id}",
             fingerprint_a=new_fp_a,
             fingerprint_b=new_fp_b,
         )
@@ -757,6 +760,9 @@ def _execute_creates(
             pair.id,
             a_id,
             new_b_id,
+            # Placeholder: IP-9 wires the real identity_key from SyncOp.
+            # Using a_id keeps uniqueness within a pair.
+            identity_key=f"legacy:{a_id}",
             fingerprint_a=item_a.fingerprint,
             fingerprint_b=new_b_fp,
         )
@@ -795,6 +801,9 @@ def _execute_creates(
             pair.id,
             new_a_id,
             b_id,
+            # Placeholder: IP-9 wires the real identity_key from SyncOp.
+            # Using b_id keeps uniqueness within a pair.
+            identity_key=f"legacy:{b_id}",
             fingerprint_a=new_a_fp,
             fingerprint_b=item_b.fingerprint,
         )

--- a/src/groupware_sync/engine.py
+++ b/src/groupware_sync/engine.py
@@ -91,9 +91,12 @@ def sync_trees(
 
     # Phase 3 — Compare trees
     log.info("Phase 3: comparing trees")
-    operations = compare_trees(
+    operations, healed_count = compare_trees(
         tree_a, tree_b, provider_a.name, provider_b.name, item_type, session
     )
+    summary.identity_pairs_healed += healed_count
+    if healed_count:
+        log.info("Healed %d stale mapping(s) by identity", healed_count)
     log.info("Phase 3 produced %d operations", len(operations))
 
     if dry_run:
@@ -718,9 +721,9 @@ def _execute_creates(
             pair.id,
             a_id,
             b_id,
-            # Placeholder: IP-9 wires the real identity_key from SyncOp.
-            # Using a_id keeps uniqueness within a pair.
-            identity_key=f"legacy:{a_id}",
+            identity_key=(
+                op_a.identity_key or op_b.identity_key or f"legacy:{a_id}"
+            ),
             fingerprint_a=new_fp_a,
             fingerprint_b=new_fp_b,
         )
@@ -760,9 +763,7 @@ def _execute_creates(
             pair.id,
             a_id,
             new_b_id,
-            # Placeholder: IP-9 wires the real identity_key from SyncOp.
-            # Using a_id keeps uniqueness within a pair.
-            identity_key=f"legacy:{a_id}",
+            identity_key=op.identity_key or f"legacy:{a_id}",
             fingerprint_a=item_a.fingerprint,
             fingerprint_b=new_b_fp,
         )
@@ -801,9 +802,7 @@ def _execute_creates(
             pair.id,
             new_a_id,
             b_id,
-            # Placeholder: IP-9 wires the real identity_key from SyncOp.
-            # Using b_id keeps uniqueness within a pair.
-            identity_key=f"legacy:{b_id}",
+            identity_key=op.identity_key or f"legacy:{b_id}",
             fingerprint_a=new_a_fp,
             fingerprint_b=item_b.fingerprint,
         )

--- a/src/groupware_sync/models.py
+++ b/src/groupware_sync/models.py
@@ -8,6 +8,7 @@ TypeSpec/FieldDef: per-type merge configuration.
 from __future__ import annotations
 
 import hashlib
+import unicodedata
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -54,8 +55,11 @@ def compute_identity_key(
     def canonical(v: object) -> str:
         if isinstance(v, dict):
             v = v.get("value", "")
-        s = str(v).strip().lower()
-        return s
+        # NFC normalize before casefold so visually-identical strings with
+        # different Unicode decompositions hash equally. casefold is stricter
+        # than lower (handles ß → ss etc). Identity values are opaque
+        # identifiers; this is defensive, not free-form text handling.
+        return unicodedata.normalize("NFC", str(v)).strip().casefold()
 
     parts: list[str] = []
     for name in identity_fields:

--- a/src/groupware_sync/models.py
+++ b/src/groupware_sync/models.py
@@ -165,6 +165,7 @@ class SyncOp:
     container_id_b: Optional[str] = None
     container_name: Optional[str] = None
     item_type: Optional[ItemType] = None
+    identity_key: Optional[str] = None
 
 
 @dataclass
@@ -199,3 +200,4 @@ class SyncSummary:
     skipped: int = 0
     errors: int = 0
     aborted: bool = False
+    identity_pairs_healed: int = 0

--- a/src/groupware_sync/models.py
+++ b/src/groupware_sync/models.py
@@ -54,7 +54,12 @@ def compute_identity_key(
     """
     def canonical(v: object) -> str:
         if isinstance(v, dict):
-            v = v.get("value", "")
+            v = v.get("value")
+        # Treat None as empty: a list entry shaped {"value": None} or a
+        # dict field that's simply absent must not turn into the string
+        # "None" and generate a spurious identity key.
+        if v is None:
+            return ""
         # NFC normalize before casefold so visually-identical strings with
         # different Unicode decompositions hash equally. casefold is stricter
         # than lower (handles ß → ss etc). Identity values are opaque

--- a/src/groupware_sync/models.py
+++ b/src/groupware_sync/models.py
@@ -41,6 +41,41 @@ class MergeStrategy(Enum):
     IGNORE = "ignore"
 
 
+def compute_identity_key(
+    fields: dict,
+    identity_fields: list[str],
+) -> Optional[str]:
+    """Canonical SHA-256 hex digest of the named fields, or None if unusable.
+
+    - Case-insensitive, whitespace-stripped canonicalization.
+    - List values: each element is normalized; order-independent.
+    - Dict values with a 'value' key: extract the value (for email/phone shapes).
+    """
+    def canonical(v: object) -> str:
+        if isinstance(v, dict):
+            v = v.get("value", "")
+        s = str(v).strip().lower()
+        return s
+
+    parts: list[str] = []
+    for name in identity_fields:
+        val = fields.get(name)
+        if val is None:
+            continue
+        if isinstance(val, list):
+            entries = sorted(filter(None, (canonical(v) for v in val)))
+            for s in entries:
+                parts.append(f"{name}={s}")
+        else:
+            s = canonical(val)
+            if s:
+                parts.append(f"{name}={s}")
+    if not parts:
+        return None
+    parts.sort()
+    return hashlib.sha256("|".join(parts).encode()).hexdigest()
+
+
 @dataclass
 class SyncNode:
     """A node in the sync tree. Containers have children; leaves don't."""
@@ -54,6 +89,7 @@ class SyncNode:
     children: list[SyncNode] = field(default_factory=list)
     state_cursor: Optional[str] = None  # protocol's state indicator for this container
     skipped: bool = False  # True if children were not fetched (state unchanged)
+    identity_key: Optional[str] = None  # cross-provider pairing key for leaves
 
     def compute_merkle(self) -> str:
         """Compute subtree hash bottom-up.

--- a/src/groupware_sync/state/db.py
+++ b/src/groupware_sync/state/db.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     create_engine,
+    inspect,
     text,
 )
 from sqlalchemy.orm import DeclarativeBase, relationship, sessionmaker
@@ -123,13 +124,49 @@ class SchemaMeta(Base):
     version = Column(String(64), nullable=False)
 
 
-def _ensure_schema_version(engine) -> None:
-    """Stamp the current schema version or rebuild the cache on mismatch.
+def _drop_cache_tables_if_stale(engine) -> None:
+    """Drop item_mapping + item_snapshot when their shape is incompatible.
 
-    Strategy: we keep structural tables (node_pair, sync_cursor) intact
-    but drop cache contents (item_snapshot, item_mapping) on version
-    mismatch. The engine's safety invariant ensures the first post-
-    rebuild sync plans no deletes.
+    Runs before create_all. Triggers in two cases:
+    1. Pre-versioning DB (no schema_meta): if item_mapping exists and
+       lacks the identity_key column, it's from before IP-3 and must go.
+    2. Versioned DB with a non-matching schema_meta row: future upgrades.
+
+    create_all then recreates the dropped tables with the current shape.
+    NodePair and SyncCursor (structural, rebuildable-adjacent) survive.
+    The tree comparison's safety invariant ensures the first post-rebuild
+    sync plans no deletes.
+    """
+    insp = inspect(engine)
+    has_schema_meta = insp.has_table("schema_meta")
+    has_item_mapping = insp.has_table("item_mapping")
+
+    should_drop = False
+    if not has_schema_meta and has_item_mapping:
+        cols = {c["name"] for c in insp.get_columns("item_mapping")}
+        if "identity_key" not in cols:
+            should_drop = True
+    elif has_schema_meta:
+        with engine.begin() as conn:
+            row = conn.execute(
+                text("SELECT version FROM schema_meta LIMIT 1")
+            ).first()
+        if row is not None and row[0] != SCHEMA_VERSION:
+            should_drop = True
+
+    if not should_drop:
+        return
+
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS item_snapshot"))
+        conn.execute(text("DROP TABLE IF EXISTS item_mapping"))
+
+
+def _ensure_schema_version(engine) -> None:
+    """Stamp schema_meta with the current version.
+
+    Assumes _drop_cache_tables_if_stale + create_all have already aligned
+    the table shape. This just writes the version marker.
     """
     with engine.begin() as conn:
         row = conn.execute(text("SELECT version FROM schema_meta LIMIT 1")).first()
@@ -139,20 +176,17 @@ def _ensure_schema_version(engine) -> None:
                 {"v": SCHEMA_VERSION},
             )
             return
-        if row[0] == SCHEMA_VERSION:
-            return
-        # Version mismatch: drop cache contents. Tables survive.
-        conn.execute(text("DELETE FROM item_snapshot"))
-        conn.execute(text("DELETE FROM item_mapping"))
-        conn.execute(
-            text("UPDATE schema_meta SET version = :v"),
-            {"v": SCHEMA_VERSION},
-        )
+        if row[0] != SCHEMA_VERSION:
+            conn.execute(
+                text("UPDATE schema_meta SET version = :v"),
+                {"v": SCHEMA_VERSION},
+            )
 
 
 def make_session_factory(database_url: str) -> sessionmaker:
     """Create engine, ensure schema + version, return a sessionmaker."""
     engine = create_engine(database_url, future=True)
+    _drop_cache_tables_if_stale(engine)
     Base.metadata.create_all(engine)
     _ensure_schema_version(engine)
     return sessionmaker(bind=engine, autoflush=True, autocommit=False)

--- a/src/groupware_sync/state/db.py
+++ b/src/groupware_sync/state/db.py
@@ -138,15 +138,19 @@ def _drop_cache_tables_if_stale(engine) -> None:
     sync plans no deletes.
     """
     insp = inspect(engine)
-    has_schema_meta = insp.has_table("schema_meta")
-    has_item_mapping = insp.has_table("item_mapping")
-
     should_drop = False
-    if not has_schema_meta and has_item_mapping:
+
+    # Physical shape first: a prior buggy migration may have stamped
+    # schema_meta at the current version without actually adding the
+    # identity_key column, so don't trust the stamp alone.
+    if insp.has_table("item_mapping"):
         cols = {c["name"] for c in insp.get_columns("item_mapping")}
         if "identity_key" not in cols:
             should_drop = True
-    elif has_schema_meta:
+
+    # Stamp mismatch (future upgrades that don't change item_mapping's
+    # columns still route through here).
+    if not should_drop and insp.has_table("schema_meta"):
         with engine.begin() as conn:
             row = conn.execute(
                 text("SELECT version FROM schema_meta LIMIT 1")

--- a/src/groupware_sync/state/db.py
+++ b/src/groupware_sync/state/db.py
@@ -22,7 +22,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import DeclarativeBase, relationship, sessionmaker
 
-
 SCHEMA_VERSION = "3-rebuild-all"
 
 

--- a/src/groupware_sync/state/db.py
+++ b/src/groupware_sync/state/db.py
@@ -5,6 +5,7 @@ Tables:
   ItemMapping   — maps individual items across providers within a pair
   ItemSnapshot  — full merged field data for a mapping
   SyncCursor    — change-tracking cursors per pair/provider
+  SchemaMeta    — schema version marker for cache-rebuild migrations
 """
 from __future__ import annotations
 
@@ -16,8 +17,12 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     create_engine,
+    text,
 )
 from sqlalchemy.orm import DeclarativeBase, relationship, sessionmaker
+
+
+SCHEMA_VERSION = "2-identity-pairing"
 
 
 class Base(DeclarativeBase):
@@ -53,12 +58,17 @@ class NodePair(Base):
 
 
 class ItemMapping(Base):
-    """Maps a single item on provider A to its counterpart on provider B."""
+    """Maps a single item on provider A to its counterpart on provider B,
+    keyed on cross-provider identity (hash of TypeSpec.identity_fields)."""
 
     __tablename__ = "item_mapping"
+    __table_args__ = (
+        UniqueConstraint("pair_id", "identity_key", name="uq_mapping_identity"),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     pair_id = Column(Integer, ForeignKey("node_pair.id", ondelete="CASCADE"), nullable=False)
+    identity_key = Column(String(64), nullable=False, index=True)
     a_item_id = Column(String(255), nullable=False)
     b_item_id = Column(String(255), nullable=False)
     fingerprint_a = Column(String(255), nullable=True)
@@ -107,8 +117,42 @@ class SyncCursor(Base):
     pair = relationship("NodePair", back_populates="cursors")
 
 
+class SchemaMeta(Base):
+    __tablename__ = "schema_meta"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    version = Column(String(64), nullable=False)
+
+
+def _ensure_schema_version(engine) -> None:
+    """Stamp the current schema version or rebuild the cache on mismatch.
+
+    Strategy: we keep structural tables (node_pair, sync_cursor) intact
+    but drop cache contents (item_snapshot, item_mapping) on version
+    mismatch. The engine's safety invariant ensures the first post-
+    rebuild sync plans no deletes.
+    """
+    with engine.begin() as conn:
+        row = conn.execute(text("SELECT version FROM schema_meta LIMIT 1")).first()
+        if row is None:
+            conn.execute(
+                text("INSERT INTO schema_meta (version) VALUES (:v)"),
+                {"v": SCHEMA_VERSION},
+            )
+            return
+        if row[0] == SCHEMA_VERSION:
+            return
+        # Version mismatch: drop cache contents. Tables survive.
+        conn.execute(text("DELETE FROM item_snapshot"))
+        conn.execute(text("DELETE FROM item_mapping"))
+        conn.execute(
+            text("UPDATE schema_meta SET version = :v"),
+            {"v": SCHEMA_VERSION},
+        )
+
+
 def make_session_factory(database_url: str) -> sessionmaker:
-    """Create engine, ensure all tables exist, and return a sessionmaker."""
+    """Create engine, ensure schema + version, return a sessionmaker."""
     engine = create_engine(database_url, future=True)
     Base.metadata.create_all(engine)
+    _ensure_schema_version(engine)
     return sessionmaker(bind=engine, autoflush=True, autocommit=False)

--- a/src/groupware_sync/state/db.py
+++ b/src/groupware_sync/state/db.py
@@ -23,7 +23,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import DeclarativeBase, relationship, sessionmaker
 
 
-SCHEMA_VERSION = "2-identity-pairing"
+SCHEMA_VERSION = "3-rebuild-all"
 
 
 class Base(DeclarativeBase):
@@ -125,17 +125,21 @@ class SchemaMeta(Base):
 
 
 def _drop_cache_tables_if_stale(engine) -> None:
-    """Drop item_mapping + item_snapshot when their shape is incompatible.
+    """Drop every cache table when the stored shape is incompatible.
 
     Runs before create_all. Triggers in two cases:
     1. Pre-versioning DB (no schema_meta): if item_mapping exists and
        lacks the identity_key column, it's from before IP-3 and must go.
     2. Versioned DB with a non-matching schema_meta row: future upgrades.
 
-    create_all then recreates the dropped tables with the current shape.
-    NodePair and SyncCursor (structural, rebuildable-adjacent) survive.
-    The tree comparison's safety invariant ensures the first post-rebuild
-    sync plans no deletes.
+    All four cache tables (item_snapshot, item_mapping, sync_cursor,
+    node_pair) are dropped together. They are fully reconstructible from
+    the providers on the next sync, and keeping partial state behind
+    confuses the adapter's state-skip path (a surviving sync_cursor +
+    node_pair tricks build_tree into skipping container children, which
+    then produces a tree with zero leaves that can never pair against
+    the other side's fresh tree). The tree comparison's safety invariant
+    ensures the first post-rebuild sync plans no deletes.
     """
     insp = inspect(engine)
     should_drop = False
@@ -164,6 +168,8 @@ def _drop_cache_tables_if_stale(engine) -> None:
     with engine.begin() as conn:
         conn.execute(text("DROP TABLE IF EXISTS item_snapshot"))
         conn.execute(text("DROP TABLE IF EXISTS item_mapping"))
+        conn.execute(text("DROP TABLE IF EXISTS sync_cursor"))
+        conn.execute(text("DROP TABLE IF EXISTS node_pair"))
 
 
 def _ensure_schema_version(engine) -> None:

--- a/src/groupware_sync/state/ops.py
+++ b/src/groupware_sync/state/ops.py
@@ -106,12 +106,14 @@ def create_mapping(
     pair_id: int,
     a_item_id: str,
     b_item_id: str,
+    identity_key: str,
     fingerprint_a: Optional[str] = None,
     fingerprint_b: Optional[str] = None,
 ) -> ItemMapping:
-    """Create and persist a new ItemMapping."""
+    """Create and persist a new ItemMapping keyed on identity."""
     mapping = ItemMapping(
         pair_id=pair_id,
+        identity_key=identity_key,
         a_item_id=a_item_id,
         b_item_id=b_item_id,
         fingerprint_a=fingerprint_a,
@@ -120,6 +122,36 @@ def create_mapping(
     s.add(mapping)
     s.flush()
     return mapping
+
+
+def get_mappings_by_identity(
+    s: Session, pair_id: int,
+) -> dict[str, ItemMapping]:
+    """Return all ItemMappings for a pair keyed by identity_key."""
+    rows = s.query(ItemMapping).filter_by(pair_id=pair_id).all()
+    return {m.identity_key: m for m in rows if m.identity_key is not None}
+
+
+def get_mapping_by_identity(
+    s: Session, pair_id: int, identity_key: str,
+) -> Optional[ItemMapping]:
+    """Look up a mapping by (pair_id, identity_key)."""
+    return (
+        s.query(ItemMapping)
+        .filter_by(pair_id=pair_id, identity_key=identity_key)
+        .first()
+    )
+
+
+def heal_mapping_ids(
+    s: Session,
+    mapping: ItemMapping,
+    new_a_item_id: str,
+    new_b_item_id: str,
+) -> None:
+    """Update provider IDs on a mapping when they've drifted. Identity stable."""
+    mapping.a_item_id = new_a_item_id
+    mapping.b_item_id = new_b_item_id
 
 
 def update_fingerprints(

--- a/src/groupware_sync/tree.py
+++ b/src/groupware_sync/tree.py
@@ -179,22 +179,37 @@ def _compare_node(
     # filter them without affecting ops recursed from child containers.
     leaf_ops: list[SyncOp] = []
 
-    by_identity_a: dict[str, SyncNode] = {}
-    unpairable_a: list[SyncNode] = []
-    for leaf in leaves_a.values():
-        if leaf.identity_key:
-            # First occurrence wins on collision within a container
-            by_identity_a.setdefault(leaf.identity_key, leaf)
-        else:
-            unpairable_a.append(leaf)
+    # Route leaves into "paired by identity" vs "unpairable" buckets.
+    # Collisions within a container (two leaves with the same identity_key)
+    # are demoted to unpairable: picking "first wins" silently drops the
+    # extra leaf, which would miss deletes/merges. Treating all colliders
+    # as unpairable means they take the create-only path, which is safe.
+    def _bucket(leaves: dict, side: str) -> tuple[dict[str, SyncNode], list[SyncNode]]:
+        by_identity: dict[str, SyncNode] = {}
+        collisions: dict[str, list[SyncNode]] = {}
+        for leaf in leaves.values():
+            if not leaf.identity_key:
+                continue
+            key = leaf.identity_key
+            if key in by_identity:
+                collisions.setdefault(key, [by_identity[key]]).append(leaf)
+            else:
+                by_identity[key] = leaf
+        unpairable: list[SyncNode] = [
+            leaf for leaf in leaves.values() if not leaf.identity_key
+        ]
+        for key, group in collisions.items():
+            log.warning(
+                "side %s: identity_key %s shared by %d leaves (%s) — "
+                "demoting to unpairable",
+                side, key, len(group), [leaf.node_id for leaf in group],
+            )
+            by_identity.pop(key, None)
+            unpairable.extend(group)
+        return by_identity, unpairable
 
-    by_identity_b: dict[str, SyncNode] = {}
-    unpairable_b: list[SyncNode] = []
-    for leaf in leaves_b.values():
-        if leaf.identity_key:
-            by_identity_b.setdefault(leaf.identity_key, leaf)
-        else:
-            unpairable_b.append(leaf)
+    by_identity_a, unpairable_a = _bucket(leaves_a, "a")
+    by_identity_b, unpairable_b = _bucket(leaves_b, "b")
 
     cached = ops.get_mappings_by_identity(session, pair.id)
     had_cache = bool(cached)
@@ -230,13 +245,16 @@ def _compare_node(
 
             if (mapping.a_item_id != leaf_a.node_id
                     or mapping.b_item_id != leaf_b.node_id):
+                # Capture before heal_mapping_ids mutates the row, so the
+                # log line shows old→new rather than new→new.
+                old_a_id, old_b_id = mapping.a_item_id, mapping.b_item_id
                 ops.heal_mapping_ids(
                     session, mapping, leaf_a.node_id, leaf_b.node_id
                 )
                 healed += 1
                 log.debug(
                     "healed mapping identity=%s: %s,%s -> %s,%s",
-                    key, mapping.a_item_id, mapping.b_item_id,
+                    key, old_a_id, old_b_id,
                     leaf_a.node_id, leaf_b.node_id,
                 )
 

--- a/src/groupware_sync/tree.py
+++ b/src/groupware_sync/tree.py
@@ -7,12 +7,14 @@ Key behaviors:
   - PRUNE: if the combined Merkle hash of both sides matches the stored hash,
     the entire subtree is skipped.
   - Container matching by name (case-insensitive).
-  - Leaf matching by stored ItemMapping.
+  - Leaf matching by identity_key (stable cross-provider hash).
   - Fingerprint comparison against stored per-side fingerprints.
+  - Safety invariant: no DELETE_ITEM emitted on runs with no cache.
 """
 from __future__ import annotations
 
 import hashlib
+import logging
 from typing import Optional
 
 from sqlalchemy.orm import Session
@@ -25,6 +27,8 @@ from groupware_sync.models import (
     SyncOp,
 )
 from groupware_sync.state import ops
+
+log = logging.getLogger(__name__)
 
 
 def _combine_merkle(hash_a: Optional[str], hash_b: Optional[str]) -> str:
@@ -166,23 +170,61 @@ def _compare_node(
                 _collect_one_side(cb, "a", item_type, prov_b, prov_a, session)
             )
 
-    # --- Match leaves via stored ItemMappings ---
-    existing_mappings = ops.get_all_mappings(session, pair.id)
+    # --- Identity-based leaf pairing ---
+    # Ops from this level's leaves are collected separately so the safety
+    # invariant (no deletes on a run with no prior cache for THIS pair) can
+    # filter them without affecting ops recursed from child containers.
+    leaf_ops: list[SyncOp] = []
 
-    # Build lookup indexes
-    mapped_a_ids: set[str] = set()
-    mapped_b_ids: set[str] = set()
+    by_identity_a: dict[str, SyncNode] = {}
+    unpairable_a: list[SyncNode] = []
+    for leaf in leaves_a.values():
+        if leaf.identity_key:
+            # First occurrence wins on collision within a container
+            by_identity_a.setdefault(leaf.identity_key, leaf)
+        else:
+            unpairable_a.append(leaf)
 
-    for mapping in existing_mappings:
-        a_id = mapping.a_item_id
-        b_id = mapping.b_item_id
-        leaf_a = leaves_a.get(a_id)
-        leaf_b = leaves_b.get(b_id)
+    by_identity_b: dict[str, SyncNode] = {}
+    unpairable_b: list[SyncNode] = []
+    for leaf in leaves_b.values():
+        if leaf.identity_key:
+            by_identity_b.setdefault(leaf.identity_key, leaf)
+        else:
+            unpairable_b.append(leaf)
+
+    cached = ops.get_mappings_by_identity(session, pair.id)
+    had_cache = bool(cached)
+
+    all_keys = set(by_identity_a) | set(by_identity_b) | set(cached)
+    for key in sorted(all_keys):
+        leaf_a = by_identity_a.get(key)
+        leaf_b = by_identity_b.get(key)
+        mapping = cached.get(key)
 
         if leaf_a is not None and leaf_b is not None:
-            # Both present — check fingerprints
-            mapped_a_ids.add(a_id)
-            mapped_b_ids.add(b_id)
+            # Both sides present — pair (merge if drift, silently heal IDs if changed).
+            if mapping is None:
+                ops.create_mapping(
+                    session, pair.id,
+                    leaf_a.node_id, leaf_b.node_id,
+                    identity_key=key,
+                    fingerprint_a=leaf_a.fingerprint,
+                    fingerprint_b=leaf_b.fingerprint,
+                )
+                continue
+
+            if (mapping.a_item_id != leaf_a.node_id
+                    or mapping.b_item_id != leaf_b.node_id):
+                ops.heal_mapping_ids(
+                    session, mapping, leaf_a.node_id, leaf_b.node_id
+                )
+                log.debug(
+                    "healed mapping identity=%s: %s,%s -> %s,%s",
+                    key, mapping.a_item_id, mapping.b_item_id,
+                    leaf_a.node_id, leaf_b.node_id,
+                )
+
             fp_changed_a = (
                 mapping.fingerprint_a is not None
                 and leaf_a.fingerprint != mapping.fingerprint_a
@@ -192,113 +234,137 @@ def _compare_node(
                 and leaf_b.fingerprint != mapping.fingerprint_b
             )
             if fp_changed_a or fp_changed_b:
-                result.append(
+                leaf_ops.append(
                     SyncOp(
                         op_type=OpType.MERGE_ITEM,
                         target_side="both",
-                        node_id=a_id,
-                        paired_node_id=b_id,
+                        node_id=leaf_a.node_id,
+                        paired_node_id=leaf_b.node_id,
                         container_id_a=node_a.node_id,
                         container_id_b=node_b.node_id,
                         item_type=item_type,
+                        identity_key=key,
                     )
                 )
-        elif leaf_a is not None and leaf_b is None:
-            # Gone from B → delete on A (propagate B's deletion)
-            mapped_a_ids.add(a_id)
-            mapped_b_ids.add(b_id)
-            result.append(
-                SyncOp(
-                    op_type=OpType.DELETE_ITEM,
-                    target_side="a",
-                    node_id=a_id,          # target item (on A)
-                    paired_node_id=b_id,   # was on B
-                    container_id_a=node_a.node_id,
-                    container_id_b=node_b.node_id,
-                    item_type=item_type,
+            continue
+
+        if leaf_a is not None and leaf_b is None:
+            # Only on A.
+            if mapping is None:
+                # Never seen before — new item on A → create on B.
+                leaf_ops.append(
+                    SyncOp(
+                        op_type=OpType.CREATE_ITEM,
+                        target_side="b",
+                        node_id=leaf_a.node_id,
+                        container_id_a=node_a.node_id,
+                        container_id_b=node_b.node_id,
+                        item_type=item_type,
+                        identity_key=key,
+                    )
                 )
-            )
-        elif leaf_b is not None and leaf_a is None:
-            # Gone from A → delete on B (propagate A's deletion)
-            mapped_a_ids.add(a_id)
-            mapped_b_ids.add(b_id)
-            result.append(
-                SyncOp(
-                    op_type=OpType.DELETE_ITEM,
-                    target_side="b",
-                    node_id=b_id,          # target item (on B)
-                    paired_node_id=a_id,   # was on A
-                    container_id_a=node_a.node_id,
-                    container_id_b=node_b.node_id,
-                    item_type=item_type,
+            else:
+                # We saw it before and it's gone from B → propagate delete to A.
+                leaf_ops.append(
+                    SyncOp(
+                        op_type=OpType.DELETE_ITEM,
+                        target_side="a",
+                        node_id=leaf_a.node_id,
+                        paired_node_id=mapping.b_item_id,
+                        container_id_a=node_a.node_id,
+                        container_id_b=node_b.node_id,
+                        item_type=item_type,
+                        identity_key=key,
+                    )
                 )
-            )
-        else:
-            # Both gone — cleanup mapping
-            mapped_a_ids.add(a_id)
-            mapped_b_ids.add(b_id)
-            result.append(
+            continue
+
+        if leaf_b is not None and leaf_a is None:
+            # Symmetric.
+            if mapping is None:
+                leaf_ops.append(
+                    SyncOp(
+                        op_type=OpType.CREATE_ITEM,
+                        target_side="a",
+                        node_id=leaf_b.node_id,
+                        container_id_a=node_a.node_id,
+                        container_id_b=node_b.node_id,
+                        item_type=item_type,
+                        identity_key=key,
+                    )
+                )
+            else:
+                leaf_ops.append(
+                    SyncOp(
+                        op_type=OpType.DELETE_ITEM,
+                        target_side="b",
+                        node_id=leaf_b.node_id,
+                        paired_node_id=mapping.a_item_id,
+                        container_id_a=node_a.node_id,
+                        container_id_b=node_b.node_id,
+                        item_type=item_type,
+                        identity_key=key,
+                    )
+                )
+            continue
+
+        # Neither side has it, but cache does → both-gone cleanup.
+        if mapping is not None:
+            leaf_ops.append(
                 SyncOp(
                     op_type=OpType.DELETE_ITEM,
                     target_side="both",
-                    node_id=a_id,
-                    paired_node_id=b_id,
+                    node_id=mapping.a_item_id,
+                    paired_node_id=mapping.b_item_id,
                     container_id_a=node_a.node_id,
                     container_id_b=node_b.node_id,
                     item_type=item_type,
+                    identity_key=key,
                 )
             )
             ops.delete_mapping(session, mapping)
 
-    # --- Unmatched leaves ---
-    # First, pair up leaves that exist on both sides by node_id (initial sync).
-    # These already exist on both providers, so we create a mapping and check
-    # fingerprints rather than generating CREATE ops.
-    unmatched_a = {lid for lid in leaves_a if lid not in mapped_a_ids}
-    unmatched_b = {lid for lid in leaves_b if lid not in mapped_b_ids}
-    paired_by_id = unmatched_a & unmatched_b
-
-    for leaf_id in paired_by_id:
-        leaf_a = leaves_a[leaf_id]
-        leaf_b = leaves_b[leaf_id]
-        # Create a mapping to record that these items are paired
-        ops.create_mapping(
-            session,
-            pair.id,
-            leaf_id,
-            leaf_id,
-            # Placeholder: IP-9 will wire the real identity_key from
-            # SyncOp.identity_key. Using leaf_id keeps uniqueness within
-            # a pair so the uq_mapping_identity constraint is satisfied.
-            identity_key=f"legacy:{leaf_id}",
-            fingerprint_a=leaf_a.fingerprint,
-            fingerprint_b=leaf_b.fingerprint,
-        )
-
-    # Leaves only on A (no match on B) → CREATE_ITEM on B
-    for leaf_id in sorted(unmatched_a - paired_by_id):
-        result.append(
+    # Unpairable leaves: always create on the other side. Legacy identity
+    # matching in _execute_creates catches duplicates during execution.
+    for leaf in unpairable_a:
+        leaf_ops.append(
             SyncOp(
                 op_type=OpType.CREATE_ITEM,
                 target_side="b",
-                node_id=leaf_id,
+                node_id=leaf.node_id,
                 container_id_a=node_a.node_id,
                 container_id_b=node_b.node_id,
                 item_type=item_type,
+                identity_key=None,
             )
         )
-    # Leaves only on B (no match on A) → CREATE_ITEM on A
-    for leaf_id in sorted(unmatched_b - paired_by_id):
-        result.append(
+    for leaf in unpairable_b:
+        leaf_ops.append(
             SyncOp(
                 op_type=OpType.CREATE_ITEM,
                 target_side="a",
-                node_id=leaf_id,
+                node_id=leaf.node_id,
                 container_id_a=node_a.node_id,
                 container_id_b=node_b.node_id,
                 item_type=item_type,
+                identity_key=None,
             )
         )
+
+    # --- Safety invariant: no deletes on a run with no prior cache. ---
+    # Scoped to THIS pair's leaf ops only; child-container ops are unaffected.
+    if not had_cache:
+        pre_count = sum(
+            1 for op in leaf_ops if op.op_type == OpType.DELETE_ITEM
+        )
+        if pre_count:
+            log.warning(
+                "no cache present for pair %s — suppressing %d planned deletes "
+                "(cache being rebuilt this run)", pair.id, pre_count,
+            )
+            leaf_ops = [op for op in leaf_ops if op.op_type != OpType.DELETE_ITEM]
+
+    result.extend(leaf_ops)
 
     # --- Update stored Merkle hash ---
     combined = _combine_merkle(node_a.merkle_hash, node_b.merkle_hash)

--- a/src/groupware_sync/tree.py
+++ b/src/groupware_sync/tree.py
@@ -44,8 +44,8 @@ def compare_trees(
     provider_b_name: str,
     item_type: ItemType,
     session: Session,
-) -> list[SyncOp]:
-    """Entry point: compare two provider trees and return sync operations."""
+) -> tuple[list[SyncOp], int]:
+    """Entry point: compare two provider trees, return (ops, healed_count)."""
     return _compare_node(
         node_a, node_b, provider_a_name, provider_b_name, item_type, session
     )
@@ -58,17 +58,18 @@ def _compare_node(
     prov_b: str,
     item_type: ItemType,
     session: Session,
-) -> list[SyncOp]:
+) -> tuple[list[SyncOp], int]:
     """Recursively compare two nodes and produce sync operations."""
     result: list[SyncOp] = []
+    healed = 0
 
     # --- One side only ---
     if node_a is not None and node_b is None:
-        return _collect_one_side(node_a, "b", item_type, prov_a, prov_b, session)
+        return _collect_one_side(node_a, "b", item_type, prov_a, prov_b, session), 0
     if node_b is not None and node_a is None:
-        return _collect_one_side(node_b, "a", item_type, prov_b, prov_a, session)
+        return _collect_one_side(node_b, "a", item_type, prov_b, prov_a, session), 0
     if node_a is None and node_b is None:
-        return result
+        return result, 0
 
     # Both exist — must both be containers at the top level of recursion
     if node_a is None or node_b is None:
@@ -94,7 +95,7 @@ def _compare_node(
                     item_type=item_type,
                 )
             )
-            return result
+            return result, healed
 
     # --- Get or create the pair ---
     pair = ops.get_or_create_pair(
@@ -136,9 +137,11 @@ def _compare_node(
         cb = containers_b.get(cname)
         if ca is not None and cb is not None:
             # Both sides have this container — recurse
-            result.extend(
-                _compare_node(ca, cb, prov_a, prov_b, item_type, session)
+            child_ops, child_healed = _compare_node(
+                ca, cb, prov_a, prov_b, item_type, session
             )
+            result.extend(child_ops)
+            healed += child_healed
         elif ca is not None and cb is None:
             # Container only on A — create on B, then recurse its children
             result.append(
@@ -219,6 +222,7 @@ def _compare_node(
                 ops.heal_mapping_ids(
                     session, mapping, leaf_a.node_id, leaf_b.node_id
                 )
+                healed += 1
                 log.debug(
                     "healed mapping identity=%s: %s,%s -> %s,%s",
                     key, mapping.a_item_id, mapping.b_item_id,
@@ -370,7 +374,7 @@ def _compare_node(
     combined = _combine_merkle(node_a.merkle_hash, node_b.merkle_hash)
     ops.update_merkle(session, pair.id, combined)
 
-    return result
+    return result, healed
 
 
 def _collect_one_side(

--- a/src/groupware_sync/tree.py
+++ b/src/groupware_sync/tree.py
@@ -267,6 +267,10 @@ def _compare_node(
             pair.id,
             leaf_id,
             leaf_id,
+            # Placeholder: IP-9 will wire the real identity_key from
+            # SyncOp.identity_key. Using leaf_id keeps uniqueness within
+            # a pair so the uq_mapping_identity constraint is satisfied.
+            identity_key=f"legacy:{leaf_id}",
             fingerprint_a=leaf_a.fingerprint,
             fingerprint_b=leaf_b.fingerprint,
         )

--- a/src/groupware_sync/tree.py
+++ b/src/groupware_sync/tree.py
@@ -199,6 +199,17 @@ def _compare_node(
     cached = ops.get_mappings_by_identity(session, pair.id)
     had_cache = bool(cached)
 
+    if leaves_a or leaves_b:
+        paired_keys = set(by_identity_a) & set(by_identity_b)
+        log.info(
+            "pair %r: a=%d (keyed=%d, unpairable=%d), "
+            "b=%d (keyed=%d, unpairable=%d), paired_by_identity=%d, cache=%d",
+            node_a.name,
+            len(leaves_a), len(by_identity_a), len(unpairable_a),
+            len(leaves_b), len(by_identity_b), len(unpairable_b),
+            len(paired_keys), len(cached),
+        )
+
     all_keys = set(by_identity_a) | set(by_identity_b) | set(cached)
     for key in sorted(all_keys):
         leaf_a = by_identity_a.get(key)

--- a/src/groupware_sync_calendar/adapters/caldav_adapter.py
+++ b/src/groupware_sync_calendar/adapters/caldav_adapter.py
@@ -23,6 +23,7 @@ from groupware_sync.models import (
     NodeType,
     SyncItem,
     SyncNode,
+    compute_identity_key,
 )
 from groupware_sync.provider import (
     NotificationCapability,
@@ -196,12 +197,23 @@ class CalDavCalendarAdapter(SyncProvider):
                     continue
 
                 etag = _text(prop, f"{{{DAV_NS}}}getetag")
+                # Derive identity_key from the href filename per the
+                # widespread CalDAV convention "<UID>.ics" (matches what
+                # our own create_item path writes). Lets CalDAV↔CalDAV
+                # pairs match by RFC 5545 UID like JMAP↔Graph do.
+                basename = href.rsplit("/", 1)[-1]
+                uid = basename[:-4] if basename.endswith(".ics") else None
+                idk = (
+                    compute_identity_key({"uid": uid}, ["uid"])
+                    if uid else None
+                )
                 leaf = SyncNode(
                     node_id=href,
                     name=href,
                     node_type=NodeType.LEAF,
                     fingerprint=etag or "",
                     item_type=ItemType.CALENDAR_EVENT,
+                    identity_key=idk,
                 )
                 cal_node.children.append(leaf)
 
@@ -368,8 +380,22 @@ class CalDavCalendarAdapter(SyncProvider):
     def create_item(
         self, container_id: str, item: SyncItem
     ) -> tuple[str, str]:
-        """Create a calendar event via PUT. Returns (href, etag)."""
-        uid = str(uuid.uuid4())
+        """Create a calendar event via PUT. Returns (href, etag).
+
+        Preserves the source-side UID when available so the resulting
+        filename ('<UID>.ics') and the body's UID match across providers.
+        Identity-based pairing reads UID from the filename, so generating
+        a fresh UUID here would leave the new resource looking unpaired
+        on the very next sync.
+        """
+        uid = item.fields.get("uid")
+        if not uid:
+            src_href = item.provider_id or ""
+            basename = src_href.rstrip("/").rsplit("/", 1)[-1]
+            if basename.endswith(".ics"):
+                uid = basename[:-4]
+        if not uid:
+            uid = str(uuid.uuid4())
         ical_text = _sync_item_to_ical(item, uid=uid)
         href = f"{container_id.rstrip('/')}/{uid}.ics"
         url = self._abs_url(href)

--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -22,6 +22,7 @@ from groupware_sync.models import (
     NodeType,
     SyncItem,
     SyncNode,
+    compute_identity_key,
 )
 from groupware_sync.provider import (
     NotificationCapability,
@@ -251,12 +252,16 @@ class GraphCalendarAdapter(SyncProvider):
                 r.raise_for_status()
                 data = r.json()
                 for event in data.get("value", []):
+                    idk = compute_identity_key(
+                        {"uid": event.get("iCalUId")}, ["uid"]
+                    )
                     leaf = SyncNode(
                         node_id=event["id"],
                         name=event["id"],
                         node_type=NodeType.LEAF,
                         fingerprint=event.get("lastModifiedDateTime", ""),
                         item_type=ItemType.CALENDAR_EVENT,
+                        identity_key=idk,
                     )
                     cal_node.children.append(leaf)
                 next_link = data.get("@odata.nextLink")

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -99,6 +99,7 @@ class JmapCalendarAdapter(SyncProvider):
         self._api_url: Optional[str] = None
         self._account_id: Optional[str] = None
         self._calendar_filter = calendar_filter  # filter by name if set
+        self._max_objects_in_get: int = 100  # overwritten from JMAP session
 
     # -- SyncProvider interface ------------------------------------------------
 
@@ -217,37 +218,44 @@ class JmapCalendarAdapter(SyncProvider):
         if not event_ids:
             return
 
-        get_results = self._call([
-            [
-                "CalendarEvent/get",
-                {
-                    "accountId": self._account_id,
-                    "ids": event_ids,
-                    "properties": ["id", "updated", "uid", "calendarIds"],
-                },
-                "g0",
-            ],
-        ])
-        for result in get_results:
-            if result[0] != "CalendarEvent/get":
-                continue
-            for event in result[1].get("list", []):
-                event_cal_ids = event.get("calendarIds") or {}
-                for cal_id in event_cal_ids:
-                    cal_node = cal_nodes_by_id.get(cal_id)
-                    if cal_node is None:
-                        continue
-                    idk = compute_identity_key(
-                        {"uid": event.get("uid")}, ["uid"]
+        batch = max(1, self._max_objects_in_get)
+        for i in range(0, len(event_ids), batch):
+            chunk = event_ids[i:i + batch]
+            get_results = self._call([
+                [
+                    "CalendarEvent/get",
+                    {
+                        "accountId": self._account_id,
+                        "ids": chunk,
+                        "properties": ["id", "updated", "uid", "calendarIds"],
+                    },
+                    "g0",
+                ],
+            ])
+            for result in get_results:
+                if result[0] != "CalendarEvent/get":
+                    log.warning(
+                        "CalendarEvent/get batch returned %r: %s",
+                        result[0], str(result[1])[:200],
                     )
-                    cal_node.children.append(SyncNode(
-                        node_id=event["id"],
-                        name=event["id"],
-                        node_type=NodeType.LEAF,
-                        fingerprint=event.get("updated", ""),
-                        item_type=ItemType.CALENDAR_EVENT,
-                        identity_key=idk,
-                    ))
+                    continue
+                for event in result[1].get("list", []):
+                    event_cal_ids = event.get("calendarIds") or {}
+                    for cal_id in event_cal_ids:
+                        cal_node = cal_nodes_by_id.get(cal_id)
+                        if cal_node is None:
+                            continue
+                        idk = compute_identity_key(
+                            {"uid": event.get("uid")}, ["uid"]
+                        )
+                        cal_node.children.append(SyncNode(
+                            node_id=event["id"],
+                            name=event["id"],
+                            node_type=NodeType.LEAF,
+                            fingerprint=event.get("updated", ""),
+                            item_type=ItemType.CALENDAR_EVENT,
+                            identity_key=idk,
+                        ))
 
     def _get_events_state(self) -> Optional[str]:
         """Get the current JMAP state for CalendarEvent."""
@@ -487,6 +495,12 @@ class JmapCalendarAdapter(SyncProvider):
         r.raise_for_status()
         session = r.json()
         self._api_url = session["apiUrl"]
+
+        core_caps = session.get("capabilities", {}).get(
+            "urn:ietf:params:jmap:core", {}
+        )
+        if isinstance(core_caps.get("maxObjectsInGet"), int):
+            self._max_objects_in_get = core_caps["maxObjectsInGet"]
 
         # Find the account with calendars capability
         for acct_id, acct in session.get("accounts", {}).items():

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -153,93 +153,101 @@ class JmapCalendarAdapter(SyncProvider):
                 # Normalize name so both sides match when paired
                 calendars[0]["name"] = "__synced__"
 
-        # 2. For each calendar, check if we can skip it
+        # 2. Build container nodes; honour per-calendar state-skip.
+        # Stalwart's CalendarEvent/query rejects inCalendars and the other
+        # spec-variant filters (tested with `unsupportedFilter` responses on
+        # inCalendars / calendarIds / inCalendarIds / calendarId, and
+        # inCalendar silently returns all events). So we can't ask JMAP for
+        # a per-calendar slice; we must fetch everything and bucket locally
+        # via the event's calendarIds map.
+        current_state = self._get_events_state()
+        cal_nodes_to_fetch: dict[str, SyncNode] = {}
         for cal in calendars:
             cal_id = cal["id"]
             stored = known_states.get(cal_id)
 
             if stored is not None:
                 stored_cursor, stored_merkle = stored
-                # Ask JMAP if state changed since stored_cursor
-                current_state = self._get_events_state()
                 if current_state and current_state == stored_cursor:
                     log.debug(
                         "skipping calendar %s (state unchanged: %s)",
-                        cal["name"],
-                        current_state,
+                        cal["name"], current_state,
                     )
-                    cal_node = SyncNode(
+                    root.children.append(SyncNode(
                         node_id=cal_id,
                         name=cal["name"],
                         node_type=NodeType.CONTAINER,
                         merkle_hash=stored_merkle,
                         state_cursor=current_state,
                         skipped=True,
-                    )
-                    root.children.append(cal_node)
+                    ))
                     continue
 
-            # State changed or no stored state — fetch children
             cal_node = SyncNode(
                 node_id=cal_id,
                 name=cal["name"],
                 node_type=NodeType.CONTAINER,
+                state_cursor=current_state,
             )
-
-            # Get current JMAP state for this type (to store for next sync)
-            current_state = self._get_events_state()
-            if current_state:
-                cal_node.state_cursor = current_state
-
-            # Query event IDs in this calendar
-            query_results = self._call([
-                [
-                    "CalendarEvent/query",
-                    {
-                        "accountId": self._account_id,
-                        "filter": {"inCalendars": [cal_id]},
-                    },
-                    "q0",
-                ],
-            ])
-            event_ids: list[str] = []
-            for result in query_results:
-                if result[0] == "CalendarEvent/query":
-                    event_ids = result[1].get("ids", [])
-
-            if event_ids:
-                # Fetch only id + updated for fingerprinting
-                get_results = self._call([
-                    [
-                        "CalendarEvent/get",
-                        {
-                            "accountId": self._account_id,
-                            "ids": event_ids,
-                            "properties": ["id", "updated", "uid"],
-                        },
-                        "g0",
-                    ],
-                ])
-                for result in get_results:
-                    if result[0] == "CalendarEvent/get":
-                        for event in result[1].get("list", []):
-                            idk = compute_identity_key(
-                                {"uid": event.get("uid")}, ["uid"]
-                            )
-                            leaf = SyncNode(
-                                node_id=event["id"],
-                                name=event["id"],
-                                node_type=NodeType.LEAF,
-                                fingerprint=event.get("updated", ""),
-                                item_type=ItemType.CALENDAR_EVENT,
-                                identity_key=idk,
-                            )
-                            cal_node.children.append(leaf)
-
             root.children.append(cal_node)
+            cal_nodes_to_fetch[cal_id] = cal_node
+
+        # 3. Fetch all events account-wide and bucket by calendarIds.
+        if cal_nodes_to_fetch:
+            self._populate_events(cal_nodes_to_fetch)
 
         root.compute_merkle()
         return root
+
+    def _populate_events(self, cal_nodes_by_id: dict[str, SyncNode]) -> None:
+        """Query all CalendarEvents account-wide, then attach each as a
+        leaf under the calendar nodes it belongs to (via calendarIds).
+        Events in calendars we didn't build nodes for are ignored."""
+        query_results = self._call([
+            [
+                "CalendarEvent/query",
+                {"accountId": self._account_id},
+                "q0",
+            ],
+        ])
+        event_ids: list[str] = []
+        for result in query_results:
+            if result[0] == "CalendarEvent/query":
+                event_ids = result[1].get("ids", [])
+        if not event_ids:
+            return
+
+        get_results = self._call([
+            [
+                "CalendarEvent/get",
+                {
+                    "accountId": self._account_id,
+                    "ids": event_ids,
+                    "properties": ["id", "updated", "uid", "calendarIds"],
+                },
+                "g0",
+            ],
+        ])
+        for result in get_results:
+            if result[0] != "CalendarEvent/get":
+                continue
+            for event in result[1].get("list", []):
+                event_cal_ids = event.get("calendarIds") or {}
+                for cal_id in event_cal_ids:
+                    cal_node = cal_nodes_by_id.get(cal_id)
+                    if cal_node is None:
+                        continue
+                    idk = compute_identity_key(
+                        {"uid": event.get("uid")}, ["uid"]
+                    )
+                    cal_node.children.append(SyncNode(
+                        node_id=event["id"],
+                        name=event["id"],
+                        node_type=NodeType.LEAF,
+                        fingerprint=event.get("updated", ""),
+                        item_type=ItemType.CALENDAR_EVENT,
+                        identity_key=idk,
+                    ))
 
     def _get_events_state(self) -> Optional[str]:
         """Get the current JMAP state for CalendarEvent."""

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -22,6 +22,7 @@ from groupware_sync.models import (
     NodeType,
     SyncItem,
     SyncNode,
+    compute_identity_key,
 )
 from groupware_sync.provider import (
     NotificationCapability,
@@ -214,7 +215,7 @@ class JmapCalendarAdapter(SyncProvider):
                         {
                             "accountId": self._account_id,
                             "ids": event_ids,
-                            "properties": ["id", "updated"],
+                            "properties": ["id", "updated", "uid"],
                         },
                         "g0",
                     ],
@@ -222,12 +223,16 @@ class JmapCalendarAdapter(SyncProvider):
                 for result in get_results:
                     if result[0] == "CalendarEvent/get":
                         for event in result[1].get("list", []):
+                            idk = compute_identity_key(
+                                {"uid": event.get("uid")}, ["uid"]
+                            )
                             leaf = SyncNode(
                                 node_id=event["id"],
                                 name=event["id"],
                                 node_type=NodeType.LEAF,
                                 fingerprint=event.get("updated", ""),
                                 item_type=ItemType.CALENDAR_EVENT,
+                                identity_key=idk,
                             )
                             cal_node.children.append(leaf)
 

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -204,21 +204,37 @@ class JmapCalendarAdapter(SyncProvider):
         """Query all CalendarEvents account-wide, then attach each as a
         leaf under the calendar nodes it belongs to (via calendarIds).
         Events in calendars we didn't build nodes for are ignored."""
-        query_results = self._call([
-            [
-                "CalendarEvent/query",
-                {"accountId": self._account_id},
-                "q0",
-            ],
-        ])
+        # JMAP servers MAY cap query responses, so paginate until we see
+        # a short page. maxObjectsInGet is the server's hard limit for
+        # get responses; query responses have their own limits but using
+        # the same batch bound is a safe upper bound and lets us keep one
+        # knob.
+        batch = max(1, self._max_objects_in_get)
         event_ids: list[str] = []
-        for result in query_results:
-            if result[0] == "CalendarEvent/query":
-                event_ids = result[1].get("ids", [])
+        position = 0
+        while True:
+            query_results = self._call([
+                [
+                    "CalendarEvent/query",
+                    {
+                        "accountId": self._account_id,
+                        "position": position,
+                        "limit": batch,
+                    },
+                    "q0",
+                ],
+            ])
+            page_ids: list[str] = []
+            for result in query_results:
+                if result[0] == "CalendarEvent/query":
+                    page_ids = result[1].get("ids", [])
+                    break
+            event_ids.extend(page_ids)
+            if len(page_ids) < batch:
+                break
+            position += len(page_ids)
         if not event_ids:
             return
-
-        batch = max(1, self._max_objects_in_get)
         for i in range(0, len(event_ids), batch):
             chunk = event_ids[i:i + batch]
             get_results = self._call([

--- a/src/groupware_sync_calendar/cli.py
+++ b/src/groupware_sync_calendar/cli.py
@@ -130,6 +130,7 @@ def sync_cmd(
         f" conflicts={summary.conflicts}"
         f" skipped={summary.skipped}"
         f" errors={summary.errors}"
+        f" healed={summary.identity_pairs_healed}"
     )
 
     if summary.errors > 0:

--- a/src/groupware_sync_contacts/adapters/carddav_adapter.py
+++ b/src/groupware_sync_contacts/adapters/carddav_adapter.py
@@ -164,6 +164,7 @@ class CardDavContactAdapter(SyncProvider):
                     node_type=NodeType.LEAF,
                     fingerprint=etag or "",
                     item_type=ItemType.CONTACT,
+                    identity_key=None,
                 )
                 ab_node.children.append(leaf)
 

--- a/src/groupware_sync_contacts/adapters/carddav_adapter.py
+++ b/src/groupware_sync_contacts/adapters/carddav_adapter.py
@@ -22,6 +22,7 @@ from groupware_sync.models import (
     NodeType,
     SyncItem,
     SyncNode,
+    compute_identity_key,
 )
 from groupware_sync.provider import (
     NotificationCapability,
@@ -158,13 +159,23 @@ class CardDavContactAdapter(SyncProvider):
                     continue
 
                 etag = _text(prop, f"{{{DAV_NS}}}getetag")
+                # Derive identity_key from the href filename per the
+                # widespread CardDAV convention "<UID>.vcf" (matches what
+                # our own create_item path writes). Lets CardDAV↔CardDAV
+                # pairs match by vCard UID cross-instance.
+                basename = href.rsplit("/", 1)[-1]
+                uid = basename[:-4] if basename.endswith(".vcf") else None
+                idk = (
+                    compute_identity_key({"uid": uid}, ["uid"])
+                    if uid else None
+                )
                 leaf = SyncNode(
                     node_id=href,
                     name=href,
                     node_type=NodeType.LEAF,
                     fingerprint=etag or "",
                     item_type=ItemType.CONTACT,
-                    identity_key=None,
+                    identity_key=idk,
                 )
                 ab_node.children.append(leaf)
 
@@ -326,8 +337,20 @@ class CardDavContactAdapter(SyncProvider):
         resp.raise_for_status()
 
     def create_item(self, container_id: str, item: SyncItem) -> tuple[str, str]:
-        """Create a contact via PUT. Returns (href, etag)."""
-        uid = str(uuid.uuid4())
+        """Create a contact via PUT. Returns (href, etag).
+
+        Preserves the source-side vCard UID when available so the resulting
+        filename ('<UID>.vcf') and the body's UID match across providers.
+        Identity-based pairing reads UID from the filename.
+        """
+        uid = item.fields.get("uid")
+        if not uid:
+            src_href = item.provider_id or ""
+            basename = src_href.rstrip("/").rsplit("/", 1)[-1]
+            if basename.endswith(".vcf"):
+                uid = basename[:-4]
+        if not uid:
+            uid = str(uuid.uuid4())
         vcard_text = _sync_item_to_vcard(item, uid=uid)
         href = f"{container_id.rstrip('/')}/{uid}.vcf"
         url = self._abs_url(href)

--- a/src/groupware_sync_contacts/adapters/graph_adapter.py
+++ b/src/groupware_sync_contacts/adapters/graph_adapter.py
@@ -172,6 +172,10 @@ class GraphContactAdapter(SyncProvider):
                 data = r.json()
                 for contact in data.get("value", []):
                     leaf = SyncNode(
+                        # identity_key=None is deliberate: see the matching
+                        # comment in contacts JmapContactAdapter.build_tree.
+                        # Graph contact id is provider-specific, not
+                        # cross-provider stable.
                         node_id=contact["id"],
                         name=contact["id"],
                         node_type=NodeType.LEAF,

--- a/src/groupware_sync_contacts/adapters/graph_adapter.py
+++ b/src/groupware_sync_contacts/adapters/graph_adapter.py
@@ -177,6 +177,7 @@ class GraphContactAdapter(SyncProvider):
                         node_type=NodeType.LEAF,
                         fingerprint=contact.get("lastModifiedDateTime", ""),
                         item_type=ItemType.CONTACT,
+                        identity_key=None,
                     )
                     folder_node.children.append(leaf)
                 next_link = data.get("@odata.nextLink")

--- a/src/groupware_sync_contacts/adapters/jmap_adapter.py
+++ b/src/groupware_sync_contacts/adapters/jmap_adapter.py
@@ -182,6 +182,7 @@ class JmapContactAdapter(SyncProvider):
                                 node_type=NodeType.LEAF,
                                 fingerprint=card.get("updated", ""),
                                 item_type=ItemType.CONTACT,
+                                identity_key=None,
                             )
                             ab_node.children.append(leaf)
 

--- a/src/groupware_sync_contacts/adapters/jmap_adapter.py
+++ b/src/groupware_sync_contacts/adapters/jmap_adapter.py
@@ -176,6 +176,13 @@ class JmapContactAdapter(SyncProvider):
                 for result in get_results:
                     if result[0] == "ContactCard/get":
                         for card in result[1].get("list", []):
+                            # identity_key=None is deliberate: contacts
+                            # lack a single cross-provider stable ID the
+                            # way calendar events have iCalUId/uid. Picking
+                            # one (emails+full_name hash etc.) needs its
+                            # own spec. Until then, cross-provider pairs
+                            # (JMAP↔Graph) fall through the unpairable
+                            # path; same-provider pairs still work.
                             leaf = SyncNode(
                                 node_id=card["id"],
                                 name=card["id"],

--- a/src/groupware_sync_contacts/cli.py
+++ b/src/groupware_sync_contacts/cli.py
@@ -141,6 +141,7 @@ def sync_cmd(
         f" conflicts={summary.conflicts}"
         f" skipped={summary.skipped}"
         f" errors={summary.errors}"
+        f" healed={summary.identity_pairs_healed}"
     )
 
     if summary.errors > 0:

--- a/tests/test_contacts_identity.py
+++ b/tests/test_contacts_identity.py
@@ -1,0 +1,43 @@
+"""Contacts adapters: identity_key on leaves is currently None by design.
+
+Contacts identity is a composite of emails + full_name (per CONTACT_SPEC),
+which requires a full-item fetch that contact build_tree doesn't do today.
+Until the follow-up spec upgrades contacts to identity-based pairing, the
+adapters surface identity_key=None explicitly so the unpairable-leaf code
+path in compare_trees handles them safely (create-only, never delete).
+
+This test asserts the current contract: leaves have identity_key=None.
+"""
+from __future__ import annotations
+
+import inspect
+
+
+def test_jmap_contact_adapter_leaf_construction_sets_identity_key_none():
+    """Structural check: build_tree source references identity_key on leaf
+    construction (sentinel: the field is explicitly addressed rather than
+    defaulted silently)."""
+    import groupware_sync_contacts.adapters.jmap_adapter as mod
+    src = inspect.getsource(mod.JmapContactAdapter.build_tree)
+    assert "identity_key=None" in src, (
+        "JmapContactAdapter.build_tree should set identity_key=None explicitly "
+        "to document the follow-up path for contacts identity."
+    )
+
+
+def test_graph_contact_adapter_leaf_construction_sets_identity_key_none():
+    import groupware_sync_contacts.adapters.graph_adapter as mod
+    src = inspect.getsource(mod.GraphContactAdapter.build_tree)
+    assert "identity_key=None" in src
+
+
+def test_carddav_contact_adapter_leaf_construction_sets_identity_key_none():
+    try:
+        import groupware_sync_contacts.adapters.carddav_adapter as mod
+        src = inspect.getsource(mod.CardDavContactAdapter.build_tree)
+    except ModuleNotFoundError:
+        # vobject might not be installed in test environment; read source directly
+        import pathlib
+        carddav_path = pathlib.Path(__file__).parent.parent / "src" / "groupware_sync_contacts" / "adapters" / "carddav_adapter.py"
+        src = carddav_path.read_text()
+    assert "identity_key=None" in src

--- a/tests/test_contacts_identity.py
+++ b/tests/test_contacts_identity.py
@@ -31,13 +31,18 @@ def test_graph_contact_adapter_leaf_construction_sets_identity_key_none():
     assert "identity_key=None" in src
 
 
-def test_carddav_contact_adapter_leaf_construction_sets_identity_key_none():
+def test_carddav_contact_adapter_leaf_construction_derives_identity_key_from_filename():
+    """CardDAV contacts derive identity_key from the '<UID>.vcf' href
+    basename (the convention both Radicale and our own create_item use),
+    which lets CardDAV↔CardDAV pairs match by vCard UID without an
+    extra body fetch."""
     try:
         import groupware_sync_contacts.adapters.carddav_adapter as mod
         src = inspect.getsource(mod.CardDavContactAdapter.build_tree)
     except ModuleNotFoundError:
-        # vobject might not be installed in test environment; read source directly
         import pathlib
         carddav_path = pathlib.Path(__file__).parent.parent / "src" / "groupware_sync_contacts" / "adapters" / "carddav_adapter.py"
         src = carddav_path.read_text()
-    assert "identity_key=None" in src
+    assert "compute_identity_key" in src
+    assert ".vcf" in src
+    assert "identity_key=idk" in src

--- a/tests/test_graph_calendar_identity.py
+++ b/tests/test_graph_calendar_identity.py
@@ -1,0 +1,82 @@
+"""Graph calendar adapter: identity_key on leaves from iCalUId."""
+from __future__ import annotations
+
+import httpx
+
+from groupware_sync.models import ItemType, compute_identity_key
+from groupware_sync_calendar.adapters.graph_adapter import (
+    GRAPH_BASE,
+    GraphCalendarAdapter,
+)
+
+
+def _adapter_with_transport(transport: httpx.MockTransport) -> GraphCalendarAdapter:
+    a = GraphCalendarAdapter("token")
+    a._client = httpx.Client(
+        base_url=GRAPH_BASE,
+        headers={"Authorization": "Bearer token"},
+        transport=transport,
+        timeout=5.0,
+    )
+    return a
+
+
+def test_build_tree_leaves_have_identity_key_from_ical_uid():
+    """Leaves' identity_key is compute_identity_key({'uid': iCalUId}, ['uid'])."""
+    responses = [
+        # GET /me/calendar (primary calendar)
+        httpx.Response(200, json={"id": "default-cal", "name": "Kalender"}),
+        # GET /me/calendars (all calendars)
+        httpx.Response(200, json={"value": [
+            {"id": "default-cal", "name": "Kalender"},
+        ]}),
+        # GET events in calendar
+        httpx.Response(200, json={"value": [
+            {"id": "graph-e1", "lastModifiedDateTime": "2026-04-17T00:00:00Z",
+             "iCalUId": "uid-one"},
+            {"id": "graph-e2", "lastModifiedDateTime": "2026-04-17T00:00:00Z",
+             "iCalUId": "uid-two"},
+        ]}),
+    ]
+    idx = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        resp = responses[idx["n"]]
+        idx["n"] += 1
+        return resp
+
+    adapter = _adapter_with_transport(httpx.MockTransport(handler))
+    root = adapter.build_tree(ItemType.CALENDAR_EVENT)
+
+    cal = root.children[0]
+    leaf_by_id = {leaf.node_id: leaf for leaf in cal.children}
+    assert leaf_by_id["graph-e1"].identity_key == compute_identity_key(
+        {"uid": "uid-one"}, ["uid"]
+    )
+    assert leaf_by_id["graph-e2"].identity_key == compute_identity_key(
+        {"uid": "uid-two"}, ["uid"]
+    )
+
+
+def test_leaf_has_no_identity_key_when_ical_uid_missing():
+    responses = [
+        httpx.Response(200, json={"id": "default-cal", "name": "Kalender"}),
+        httpx.Response(200, json={"value": [
+            {"id": "default-cal", "name": "Kalender"},
+        ]}),
+        httpx.Response(200, json={"value": [
+            {"id": "graph-e1", "lastModifiedDateTime": "2026-04-17T00:00:00Z"},
+        ]}),
+    ]
+    idx = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        resp = responses[idx["n"]]
+        idx["n"] += 1
+        return resp
+
+    adapter = _adapter_with_transport(httpx.MockTransport(handler))
+    root = adapter.build_tree(ItemType.CALENDAR_EVENT)
+
+    leaf = root.children[0].children[0]
+    assert leaf.identity_key is None

--- a/tests/test_identity_key.py
+++ b/tests/test_identity_key.py
@@ -53,6 +53,22 @@ def test_multiple_identity_fields_combined():
     assert a == b
 
 
+def test_unicode_nfc_nfd_equivalence():
+    import unicodedata
+    pre = "café"  # pre-composed
+    decomposed = unicodedata.normalize("NFD", pre)
+    assert pre != decomposed  # sanity: different byte sequences
+    a = compute_identity_key({"uid": pre}, ["uid"])
+    b = compute_identity_key({"uid": decomposed}, ["uid"])
+    assert a == b
+
+
+def test_casefold_handles_german_eszett():
+    a = compute_identity_key({"uid": "straße"}, ["uid"])
+    b = compute_identity_key({"uid": "STRASSE"}, ["uid"])
+    assert a == b
+
+
 def test_sync_node_has_identity_key_field():
     from groupware_sync.models import NodeType, SyncNode
     leaf = SyncNode("n", "n", NodeType.LEAF, fingerprint="fp", identity_key="abc")

--- a/tests/test_identity_key.py
+++ b/tests/test_identity_key.py
@@ -1,0 +1,62 @@
+"""Unit tests for compute_identity_key."""
+from groupware_sync.models import compute_identity_key
+
+
+def test_returns_none_for_empty_fields():
+    assert compute_identity_key({}, ["uid"]) is None
+    assert compute_identity_key({"uid": None}, ["uid"]) is None
+    assert compute_identity_key({"uid": ""}, ["uid"]) is None
+
+
+def test_stable_hash_for_same_input():
+    a = compute_identity_key({"uid": "abc-123"}, ["uid"])
+    b = compute_identity_key({"uid": "abc-123"}, ["uid"])
+    assert a == b
+    assert len(a) == 64  # sha256 hex
+
+
+def test_case_insensitive_canonicalization():
+    a = compute_identity_key({"uid": "ABC-123"}, ["uid"])
+    b = compute_identity_key({"uid": "abc-123"}, ["uid"])
+    assert a == b
+
+
+def test_whitespace_stripped():
+    a = compute_identity_key({"uid": "  abc  "}, ["uid"])
+    b = compute_identity_key({"uid": "abc"}, ["uid"])
+    assert a == b
+
+
+def test_different_values_produce_different_hashes():
+    a = compute_identity_key({"uid": "abc"}, ["uid"])
+    b = compute_identity_key({"uid": "abd"}, ["uid"])
+    assert a != b
+
+
+def test_list_values_normalized():
+    # emails-like: list of dicts with 'value' key
+    a = compute_identity_key(
+        {"emails": [{"type": "work", "value": "X@Y.Z"}, {"type": "home", "value": "a@b.c"}]},
+        ["emails"],
+    )
+    b = compute_identity_key(
+        {"emails": [{"value": "a@b.c"}, {"value": "x@y.z"}]},
+        ["emails"],
+    )
+    # Order-independent and case-insensitive
+    assert a == b
+
+
+def test_multiple_identity_fields_combined():
+    a = compute_identity_key({"uid": "u1", "email": "e1"}, ["uid", "email"])
+    b = compute_identity_key({"email": "e1", "uid": "u1"}, ["uid", "email"])
+    assert a == b
+
+
+def test_sync_node_has_identity_key_field():
+    from groupware_sync.models import NodeType, SyncNode
+    leaf = SyncNode("n", "n", NodeType.LEAF, fingerprint="fp", identity_key="abc")
+    assert leaf.identity_key == "abc"
+
+    leaf_no_key = SyncNode("n", "n", NodeType.LEAF, fingerprint="fp")
+    assert leaf_no_key.identity_key is None

--- a/tests/test_identity_key.py
+++ b/tests/test_identity_key.py
@@ -63,6 +63,22 @@ def test_unicode_nfc_nfd_equivalence():
     assert a == b
 
 
+def test_dict_value_none_does_not_produce_spurious_key():
+    """Dict entries shaped {"value": None} must normalize to empty,
+    not to the string "None" — otherwise compute_identity_key would
+    return a non-None hash for missing data and accidentally pair
+    unrelated records."""
+    assert compute_identity_key({"emails": [{"value": None}]}, ["emails"]) is None
+    assert compute_identity_key({"uid": {"value": None}}, ["uid"]) is None
+    # Sanity: mixed list with one real value still produces a key
+    a = compute_identity_key(
+        {"emails": [{"value": None}, {"value": "a@b.c"}]},
+        ["emails"],
+    )
+    b = compute_identity_key({"emails": [{"value": "a@b.c"}]}, ["emails"])
+    assert a == b
+
+
 def test_casefold_handles_german_eszett():
     a = compute_identity_key({"uid": "straße"}, ["uid"])
     b = compute_identity_key({"uid": "STRASSE"}, ["uid"])

--- a/tests/test_incident_regression.py
+++ b/tests/test_incident_regression.py
@@ -1,0 +1,101 @@
+"""Regression test for the 2026-04-16 incident.
+
+Scenario: first sync pairs 100 events (Graph ↔ Stalwart). Between syncs,
+Stalwart's provider IDs drift (the JMAP ids change between query responses).
+With identity-based pairing + cache heals, the second sync must plan zero
+deletes.
+"""
+from __future__ import annotations
+
+import pytest
+
+from groupware_sync.models import ItemType, NodeType, OpType, SyncNode, compute_identity_key
+from groupware_sync.state import ops
+from groupware_sync.state.db import make_session_factory
+from groupware_sync.tree import compare_trees
+
+
+@pytest.fixture
+def session(tmp_path):
+    db_path = tmp_path / "regression.db"
+    sf = make_session_factory(f"sqlite:///{db_path}")
+    s = sf()
+    yield s
+    s.close()
+
+
+def _leaf(nid: str, fp: str, uid: str) -> SyncNode:
+    return SyncNode(
+        nid, nid, NodeType.LEAF, fingerprint=fp,
+        identity_key=compute_identity_key({"uid": uid}, ["uid"]),
+        item_type=ItemType.CALENDAR_EVENT,
+    )
+
+
+def _tree(leaves: list[SyncNode]) -> SyncNode:
+    c = SyncNode("cal", "cal", NodeType.CONTAINER, children=leaves)
+    r = SyncNode("root", "root", NodeType.CONTAINER, children=[c])
+    r.compute_merkle()
+    return r
+
+
+def test_id_drift_does_not_produce_deletes(session):
+    """1. First sync pairs 100 events by identity → mappings populated.
+    2. Second sync: stalwart IDs drift, Graph IDs stable. Both sides have
+       same 100 events by identity.
+    3. Assert: zero DELETE ops, 100 healed.
+    """
+    # --- First sync: populate mappings ---
+    graph_leaves_1 = [
+        _leaf(f"graph-{i}", "fp-original", f"uid-{i}") for i in range(100)
+    ]
+    jmap_leaves_1 = [
+        _leaf(f"jmap-v1-{i}", "fp-original", f"uid-{i}") for i in range(100)
+    ]
+    tree_a_1 = _tree(jmap_leaves_1)
+    tree_b_1 = _tree(graph_leaves_1)
+    ops_1, healed_1 = compare_trees(
+        tree_a_1, tree_b_1, "stalwart", "m365", ItemType.CALENDAR_EVENT, session
+    )
+    # First sync has no prior cache — safety invariant applies, deletes suppressed.
+    # Items on both sides pair silently (no ops emitted).
+    assert [o for o in ops_1 if o.op_type == OpType.DELETE_ITEM] == []
+    assert healed_1 == 0
+    session.flush()
+
+    # Verify 100 mappings created
+    pair = ops.get_pair(session, "stalwart", "cal", "m365", "cal")
+    cached = ops.get_mappings_by_identity(session, pair.id)
+    assert len(cached) == 100
+
+    # --- Second sync: stalwart IDs drift ---
+    graph_leaves_2 = [
+        _leaf(f"graph-{i}", "fp-original", f"uid-{i}") for i in range(100)
+    ]
+    jmap_leaves_2 = [
+        # Every ID drifted
+        _leaf(f"jmap-v2-{i}", "fp-original", f"uid-{i}") for i in range(100)
+    ]
+    tree_a_2 = _tree(jmap_leaves_2)
+    tree_b_2 = _tree(graph_leaves_2)
+    ops_2, healed_2 = compare_trees(
+        tree_a_2, tree_b_2, "stalwart", "m365", ItemType.CALENDAR_EVENT, session
+    )
+
+    # No deletes, no creates, no merges — all items paired by identity and healed
+    deletes = [o for o in ops_2 if o.op_type == OpType.DELETE_ITEM]
+    creates = [o for o in ops_2 if o.op_type == OpType.CREATE_ITEM]
+    merges = [o for o in ops_2 if o.op_type == OpType.MERGE_ITEM]
+    assert deletes == [], f"regression: {len(deletes)} delete ops planned"
+    assert creates == [], f"unexpected: {len(creates)} create ops planned"
+    assert merges == [], f"unexpected: {len(merges)} merge ops planned"
+    assert healed_2 == 100, (
+        f"expected all 100 mappings healed, got {healed_2}"
+    )
+
+    # Mappings now reference new JMAP IDs
+    healed_cache = ops.get_mappings_by_identity(session, pair.id)
+    for i in range(100):
+        key = compute_identity_key({"uid": f"uid-{i}"}, ["uid"])
+        m = healed_cache[key]
+        assert m.a_item_id == f"jmap-v2-{i}"

--- a/tests/test_jmap_calendar_identity.py
+++ b/tests/test_jmap_calendar_identity.py
@@ -110,6 +110,46 @@ def test_events_bucketed_by_calendar_ids_no_inCalendars_filter():
     assert {c.node_id for c in cal_by_id["cal_b"].children} == {"e2"}
 
 
+def test_events_batched_by_max_objects_in_get():
+    """Stalwart rejects oversized CalendarEvent/get calls with
+    requestTooLarge. The adapter must chunk get requests according to
+    maxObjectsInGet from the JMAP session.
+    """
+    get_call_sizes: list[int] = []
+
+    def fake_call(self, methods):  # noqa: ANN001
+        out = []
+        for m in methods:
+            name = m[0]
+            args = m[1]
+            cid = m[2]
+            if name == "Calendar/get":
+                out.append([name, {"list": [{"id": "cal1", "name": "K"}]}, cid])
+            elif name == "CalendarEvent/query":
+                out.append([name, {"ids": [f"e{i}" for i in range(250)]}, cid])
+            elif name == "CalendarEvent/get":
+                ids = args.get("ids", [])
+                get_call_sizes.append(len(ids))
+                out.append([name, {"list": [
+                    {"id": eid, "updated": "2026-04-17T00:00:00Z",
+                     "uid": f"u-{eid}", "calendarIds": {"cal1": True}}
+                    for eid in ids
+                ]}, cid])
+        return out
+
+    adapter = _make_adapter()
+    adapter._max_objects_in_get = 100
+    with patch.object(JmapCalendarAdapter, "_call", fake_call):
+        with patch.object(JmapCalendarAdapter, "_get_events_state", return_value=None):
+            root = adapter.build_tree(ItemType.CALENDAR_EVENT)
+
+    assert get_call_sizes == [100, 100, 50], (
+        f"expected 3 batched gets of 100, 100, 50, got {get_call_sizes}"
+    )
+    cal = root.children[0]
+    assert len(cal.children) == 250
+
+
 def test_leaf_has_no_identity_key_when_uid_missing():
     def fake_call(self, methods):  # noqa: ANN001
         out = []

--- a/tests/test_jmap_calendar_identity.py
+++ b/tests/test_jmap_calendar_identity.py
@@ -110,11 +110,14 @@ def test_events_bucketed_by_calendar_ids_no_inCalendars_filter():
     assert {c.node_id for c in cal_by_id["cal_b"].children} == {"e2"}
 
 
-def test_events_batched_by_max_objects_in_get():
-    """Stalwart rejects oversized CalendarEvent/get calls with
-    requestTooLarge. The adapter must chunk get requests according to
-    maxObjectsInGet from the JMAP session.
+def test_events_paginated_and_batched_by_max_objects_in_get():
+    """Both CalendarEvent/query (pagination) and CalendarEvent/get
+    (batching) respect maxObjectsInGet. The query mock honours
+    position+limit so we can verify the adapter advances the cursor
+    and stops on a short page rather than assuming a single response.
     """
+    all_ids = [f"e{i}" for i in range(250)]
+    query_windows: list[tuple[int, int]] = []
     get_call_sizes: list[int] = []
 
     def fake_call(self, methods):  # noqa: ANN001
@@ -126,7 +129,11 @@ def test_events_batched_by_max_objects_in_get():
             if name == "Calendar/get":
                 out.append([name, {"list": [{"id": "cal1", "name": "K"}]}, cid])
             elif name == "CalendarEvent/query":
-                out.append([name, {"ids": [f"e{i}" for i in range(250)]}, cid])
+                position = args.get("position", 0)
+                limit = args.get("limit", len(all_ids))
+                page = all_ids[position:position + limit]
+                query_windows.append((position, len(page)))
+                out.append([name, {"ids": page}, cid])
             elif name == "CalendarEvent/get":
                 ids = args.get("ids", [])
                 get_call_sizes.append(len(ids))
@@ -143,6 +150,9 @@ def test_events_batched_by_max_objects_in_get():
         with patch.object(JmapCalendarAdapter, "_get_events_state", return_value=None):
             root = adapter.build_tree(ItemType.CALENDAR_EVENT)
 
+    assert query_windows == [(0, 100), (100, 100), (200, 50)], (
+        f"expected 3 paginated query windows, got {query_windows}"
+    )
     assert get_call_sizes == [100, 100, 50], (
         f"expected 3 batched gets of 100, 100, 50, got {get_call_sizes}"
     )

--- a/tests/test_jmap_calendar_identity.py
+++ b/tests/test_jmap_calendar_identity.py
@@ -30,8 +30,10 @@ def test_build_tree_requests_uid_property():
                 out.append([name, {"ids": ["e1", "e2"]}, cid])
             elif name == "CalendarEvent/get":
                 out.append([name, {"list": [
-                    {"id": "e1", "updated": "2026-04-17T00:00:00Z", "uid": "uid-one"},
-                    {"id": "e2", "updated": "2026-04-17T00:00:00Z", "uid": "uid-two"},
+                    {"id": "e1", "updated": "2026-04-17T00:00:00Z",
+                     "uid": "uid-one", "calendarIds": {"cal1": True}},
+                    {"id": "e2", "updated": "2026-04-17T00:00:00Z",
+                     "uid": "uid-two", "calendarIds": {"cal1": True}},
                 ]}, cid])
         return out
 
@@ -40,11 +42,12 @@ def test_build_tree_requests_uid_property():
         with patch.object(JmapCalendarAdapter, "_get_events_state", return_value=None):
             root = adapter.build_tree(ItemType.CALENDAR_EVENT)
 
-    # Assert: the CalendarEvent/get invocation requested 'uid'
+    # Assert: the CalendarEvent/get invocation requested 'uid' + 'calendarIds'
     get_calls = [m for call in captured for m in call if m[0] == "CalendarEvent/get"]
     assert get_calls, "no CalendarEvent/get calls made"
     props = get_calls[0][1].get("properties", [])
     assert "uid" in props, f"expected 'uid' in properties, got {props}"
+    assert "calendarIds" in props, f"expected 'calendarIds' in properties, got {props}"
 
     # Assert: leaves carry identity_key derived from uid
     cal = root.children[0]
@@ -56,6 +59,55 @@ def test_build_tree_requests_uid_property():
     assert leaf_by_id["e2"].identity_key == compute_identity_key(
         {"uid": "uid-two"}, ["uid"]
     )
+
+
+def test_events_bucketed_by_calendar_ids_no_inCalendars_filter():
+    """Stalwart rejects inCalendars filters. The adapter must query once
+    account-wide and bucket events into the right calendar container
+    using the event's calendarIds map.
+    """
+    captured: list = []
+
+    def fake_call(self, methods):  # noqa: ANN001
+        captured.append(methods)
+        out = []
+        for m in methods:
+            name = m[0]
+            cid = m[2]
+            if name == "Calendar/get":
+                out.append([name, {"list": [
+                    {"id": "cal_a", "name": "A"},
+                    {"id": "cal_b", "name": "B"},
+                ]}, cid])
+            elif name == "CalendarEvent/query":
+                out.append([name, {"ids": ["e1", "e2", "e3"]}, cid])
+            elif name == "CalendarEvent/get":
+                out.append([name, {"list": [
+                    {"id": "e1", "updated": "2026-04-17T00:00:00Z",
+                     "uid": "u1", "calendarIds": {"cal_a": True}},
+                    {"id": "e2", "updated": "2026-04-17T00:00:00Z",
+                     "uid": "u2", "calendarIds": {"cal_b": True}},
+                    {"id": "e3", "updated": "2026-04-17T00:00:00Z",
+                     "uid": "u3", "calendarIds": {"cal_a": True}},
+                ]}, cid])
+        return out
+
+    adapter = _make_adapter()
+    with patch.object(JmapCalendarAdapter, "_call", fake_call):
+        with patch.object(JmapCalendarAdapter, "_get_events_state", return_value=None):
+            root = adapter.build_tree(ItemType.CALENDAR_EVENT)
+
+    # No inCalendars / calendarIds / inCalendar filter sent to Stalwart.
+    query_calls = [m for call in captured for m in call if m[0] == "CalendarEvent/query"]
+    for qc in query_calls:
+        assert "filter" not in qc[1], (
+            f"CalendarEvent/query must not send a filter: {qc[1]}"
+        )
+
+    # Events bucketed to the correct container
+    cal_by_id = {c.node_id: c for c in root.children}
+    assert {c.node_id for c in cal_by_id["cal_a"].children} == {"e1", "e3"}
+    assert {c.node_id for c in cal_by_id["cal_b"].children} == {"e2"}
 
 
 def test_leaf_has_no_identity_key_when_uid_missing():
@@ -70,7 +122,8 @@ def test_leaf_has_no_identity_key_when_uid_missing():
                 out.append([name, {"ids": ["e1"]}, cid])
             elif name == "CalendarEvent/get":
                 out.append([name, {"list": [
-                    {"id": "e1", "updated": "2026-04-17T00:00:00Z"},
+                    {"id": "e1", "updated": "2026-04-17T00:00:00Z",
+                     "calendarIds": {"cal1": True}},
                 ]}, cid])
         return out
 

--- a/tests/test_jmap_calendar_identity.py
+++ b/tests/test_jmap_calendar_identity.py
@@ -1,0 +1,83 @@
+"""JMAP calendar adapter: identity_key on leaves from uid."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from groupware_sync.models import ItemType, NodeType, compute_identity_key
+from groupware_sync_calendar.adapters.jmap_adapter import JmapCalendarAdapter
+
+
+def _make_adapter() -> JmapCalendarAdapter:
+    a = JmapCalendarAdapter("https://example.invalid/jmap", "token")
+    a._api_url = "https://example.invalid/jmap/api"
+    a._account_id = "u0"
+    return a
+
+
+def test_build_tree_requests_uid_property():
+    """The CalendarEvent/get call in build_tree must include 'uid' in properties."""
+    captured: list = []
+
+    def fake_call(self, methods):  # noqa: ANN001
+        captured.append(methods)
+        out = []
+        for m in methods:
+            name = m[0]
+            cid = m[2]
+            if name == "Calendar/get":
+                out.append([name, {"list": [{"id": "cal1", "name": "Kalender"}]}, cid])
+            elif name == "CalendarEvent/query":
+                out.append([name, {"ids": ["e1", "e2"]}, cid])
+            elif name == "CalendarEvent/get":
+                out.append([name, {"list": [
+                    {"id": "e1", "updated": "2026-04-17T00:00:00Z", "uid": "uid-one"},
+                    {"id": "e2", "updated": "2026-04-17T00:00:00Z", "uid": "uid-two"},
+                ]}, cid])
+        return out
+
+    adapter = _make_adapter()
+    with patch.object(JmapCalendarAdapter, "_call", fake_call):
+        with patch.object(JmapCalendarAdapter, "_get_events_state", return_value=None):
+            root = adapter.build_tree(ItemType.CALENDAR_EVENT)
+
+    # Assert: the CalendarEvent/get invocation requested 'uid'
+    get_calls = [m for call in captured for m in call if m[0] == "CalendarEvent/get"]
+    assert get_calls, "no CalendarEvent/get calls made"
+    props = get_calls[0][1].get("properties", [])
+    assert "uid" in props, f"expected 'uid' in properties, got {props}"
+
+    # Assert: leaves carry identity_key derived from uid
+    cal = root.children[0]
+    assert cal.node_type == NodeType.CONTAINER
+    leaf_by_id = {c.node_id: c for c in cal.children}
+    assert leaf_by_id["e1"].identity_key == compute_identity_key(
+        {"uid": "uid-one"}, ["uid"]
+    )
+    assert leaf_by_id["e2"].identity_key == compute_identity_key(
+        {"uid": "uid-two"}, ["uid"]
+    )
+
+
+def test_leaf_has_no_identity_key_when_uid_missing():
+    def fake_call(self, methods):  # noqa: ANN001
+        out = []
+        for m in methods:
+            name = m[0]
+            cid = m[2]
+            if name == "Calendar/get":
+                out.append([name, {"list": [{"id": "cal1", "name": "Kalender"}]}, cid])
+            elif name == "CalendarEvent/query":
+                out.append([name, {"ids": ["e1"]}, cid])
+            elif name == "CalendarEvent/get":
+                out.append([name, {"list": [
+                    {"id": "e1", "updated": "2026-04-17T00:00:00Z"},
+                ]}, cid])
+        return out
+
+    adapter = _make_adapter()
+    with patch.object(JmapCalendarAdapter, "_call", fake_call):
+        with patch.object(JmapCalendarAdapter, "_get_events_state", return_value=None):
+            root = adapter.build_tree(ItemType.CALENDAR_EVENT)
+
+    leaf = root.children[0].children[0]
+    assert leaf.identity_key is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,8 +2,10 @@
 from groupware_sync.models import (
     ItemType,
     NodeType,
+    OpType,
     SyncItem,
     SyncNode,
+    SyncOp,
     SyncSummary,
 )
 from groupware_sync.provider import (
@@ -139,3 +141,28 @@ def test_sync_summary_aborted_defaults_false():
 def test_sync_summary_aborted_settable():
     s = SyncSummary(aborted=True)
     assert s.aborted is True
+
+
+def test_sync_summary_identity_pairs_healed_defaults_zero():
+    s = SyncSummary()
+    assert s.identity_pairs_healed == 0
+
+
+def test_sync_summary_identity_pairs_healed_settable():
+    s = SyncSummary(identity_pairs_healed=42)
+    assert s.identity_pairs_healed == 42
+
+
+def test_sync_op_has_identity_key():
+    op = SyncOp(
+        op_type=OpType.CREATE_ITEM,
+        target_side="b",
+        node_id="x",
+        identity_key="sha256hex",
+    )
+    assert op.identity_key == "sha256hex"
+
+
+def test_sync_op_identity_key_defaults_none():
+    op = SyncOp(op_type=OpType.SKIP_SUBTREE, target_side="b", node_id="x")
+    assert op.identity_key is None

--- a/tests/test_state_ops.py
+++ b/tests/test_state_ops.py
@@ -36,7 +36,11 @@ def test_create_and_get_mapping(session):
     pair = ops.get_or_create_pair(
         session, "contact", "a", "b1", "b", "b2", "test"
     )
-    m = ops.create_mapping(session, pair.id, "a1", "b1", "fp_a", "fp_b")
+    m = ops.create_mapping(
+        session, pair.id, "a1", "b1",
+        identity_key="test-identity-1",
+        fingerprint_a="fp_a", fingerprint_b="fp_b",
+    )
     assert m.fingerprint_a == "fp_a"
     assert m.fingerprint_b == "fp_b"
     assert ops.get_mapping_by_a(session, pair.id, "a1") is not None
@@ -48,7 +52,9 @@ def test_delete_mapping_cascades_snapshot(session):
     pair = ops.get_or_create_pair(
         session, "contact", "a", "b1", "b", "b2", "test"
     )
-    m = ops.create_mapping(session, pair.id, "a1", "b1")
+    m = ops.create_mapping(
+        session, pair.id, "a1", "b1", identity_key="test-identity-2",
+    )
     item = SyncItem("a1", ItemType.CONTACT, {"full_name": "Test"})
     ops.save_snapshot(session, m.id, item)
     assert ops.get_snapshot(session, m.id) is not None
@@ -61,7 +67,9 @@ def test_snapshot_round_trip(session):
     pair = ops.get_or_create_pair(
         session, "contact", "a", "b1", "b", "b2", "test"
     )
-    m = ops.create_mapping(session, pair.id, "a1", "b1")
+    m = ops.create_mapping(
+        session, pair.id, "a1", "b1", identity_key="test-identity-3",
+    )
     item = SyncItem("a1", ItemType.CONTACT, {"full_name": "Alice", "emails": ["a@b.com"]})
     ops.save_snapshot(session, m.id, item)
     snap = ops.get_snapshot(session, m.id)
@@ -74,7 +82,9 @@ def test_snapshot_upsert(session):
     pair = ops.get_or_create_pair(
         session, "contact", "a", "b1", "b", "b2", "test"
     )
-    m = ops.create_mapping(session, pair.id, "a1", "b1")
+    m = ops.create_mapping(
+        session, pair.id, "a1", "b1", identity_key="test-identity-4",
+    )
     item1 = SyncItem("a1", ItemType.CONTACT, {"full_name": "Alice"})
     ops.save_snapshot(session, m.id, item1)
     item2 = SyncItem("a1", ItemType.CONTACT, {"full_name": "Alice Updated"})
@@ -110,7 +120,9 @@ def test_update_fingerprints(session):
     pair = ops.get_or_create_pair(
         session, "contact", "a", "b1", "b", "b2", "test"
     )
-    m = ops.create_mapping(session, pair.id, "a1", "b1")
+    m = ops.create_mapping(
+        session, pair.id, "a1", "b1", identity_key="test-identity-5",
+    )
     assert m.fingerprint_a is None
     ops.update_fingerprints(session, m, fingerprint_a="new_a", fingerprint_b="new_b")
     assert m.fingerprint_a == "new_a"

--- a/tests/test_state_ops_identity.py
+++ b/tests/test_state_ops_identity.py
@@ -102,8 +102,9 @@ def test_heal_mapping_ids_updates_provider_ids(session):
 
 def test_cache_rebuild_on_schema_version_mismatch(tmp_path):
     """Simulate an older schema by stamping a different version, then
-    re-opening the DB. Mappings should be cleared; NodePairs should
-    survive."""
+    re-opening the DB. All cache tables (mappings, pairs, cursors)
+    should be cleared — they are reconstructible from the providers,
+    and a partial carry-over confuses the adapter state-skip path."""
     db_path = tmp_path / "old.db"
 
     # First session: populate
@@ -122,13 +123,14 @@ def test_cache_rebuild_on_schema_version_mismatch(tmp_path):
     s.commit()
     s.close()
 
-    # Second session: factory should detect mismatch and rebuild mappings
+    # Second session: factory should detect mismatch and rebuild all cache
     sf2 = make_session_factory(f"sqlite:///{db_path}")
     s2 = sf2()
-    mappings = s2.query(ItemMapping).all()
-    assert mappings == [], "mappings should be rebuilt on version mismatch"
-    pairs = s2.query(NodePair).all()
-    assert len(pairs) == 1, "NodePairs should survive"
+    assert s2.query(ItemMapping).all() == [], "mappings should be rebuilt"
+    assert s2.query(NodePair).all() == [], (
+        "NodePairs must be rebuilt too — a surviving pair carries a "
+        "merkle_hash that can mislead the adapter's state-skip path"
+    )
     row = s2.execute(text("SELECT version FROM schema_meta")).first()
     assert row[0] == SCHEMA_VERSION
     s2.close()
@@ -255,10 +257,9 @@ def test_upgrade_from_pre_versioning_db_drops_old_item_mapping(tmp_path):
         "identity_key column missing — factory didn't migrate the legacy table"
     )
 
-    # Cache rebuilt — no mappings
+    # All cache tables rebuilt — nothing from the legacy DB survives
     assert s.query(ItemMapping).all() == []
-    # Structural data (NodePairs) preserved
-    assert len(s.query(NodePair).all()) == 1
+    assert s.query(NodePair).all() == []
     # Schema stamped
     version_row = s.execute(text("SELECT version FROM schema_meta")).first()
     assert version_row[0] == SCHEMA_VERSION

--- a/tests/test_state_ops_identity.py
+++ b/tests/test_state_ops_identity.py
@@ -1,0 +1,134 @@
+"""Tests for state DB identity_key column + cache-rebuild migration."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from groupware_sync.state import ops
+from groupware_sync.state.db import (
+    ItemMapping,
+    NodePair,
+    SCHEMA_VERSION,
+    make_session_factory,
+)
+
+
+@pytest.fixture
+def session(tmp_path):
+    db_path = tmp_path / "test.db"
+    sf = make_session_factory(f"sqlite:///{db_path}")
+    s = sf()
+    yield s
+    s.close()
+
+
+def test_schema_version_stamped(session):
+    row = session.execute(text("SELECT version FROM schema_meta")).first()
+    assert row is not None
+    assert row[0] == SCHEMA_VERSION
+
+
+def test_item_mapping_has_identity_key_column(session):
+    columns = session.execute(
+        text("PRAGMA table_info(item_mapping)")
+    ).fetchall()
+    names = {row[1] for row in columns}
+    assert "identity_key" in names
+
+
+def test_create_mapping_requires_identity_key(session):
+    pair = ops.get_or_create_pair(
+        session, "calendar_event", "a", "ca", "b", "cb", "calname"
+    )
+    m = ops.create_mapping(
+        session, pair.id, "a1", "b1",
+        identity_key="sha256hex-value",
+        fingerprint_a="fpa", fingerprint_b="fpb",
+    )
+    assert m.identity_key == "sha256hex-value"
+
+
+def test_get_mappings_by_identity_returns_dict(session):
+    pair = ops.get_or_create_pair(
+        session, "calendar_event", "a", "ca", "b", "cb", "calname"
+    )
+    ops.create_mapping(
+        session, pair.id, "a1", "b1", identity_key="k1",
+        fingerprint_a="fpa", fingerprint_b="fpb",
+    )
+    ops.create_mapping(
+        session, pair.id, "a2", "b2", identity_key="k2",
+        fingerprint_a="fpa2", fingerprint_b="fpb2",
+    )
+    session.flush()
+
+    by_id = ops.get_mappings_by_identity(session, pair.id)
+    assert set(by_id.keys()) == {"k1", "k2"}
+    assert by_id["k1"].a_item_id == "a1"
+    assert by_id["k2"].b_item_id == "b2"
+
+
+def test_get_mapping_by_identity_returns_one(session):
+    pair = ops.get_or_create_pair(
+        session, "calendar_event", "a", "ca", "b", "cb", "calname"
+    )
+    ops.create_mapping(
+        session, pair.id, "a1", "b1", identity_key="k1",
+        fingerprint_a="fpa", fingerprint_b="fpb",
+    )
+    session.flush()
+
+    m = ops.get_mapping_by_identity(session, pair.id, "k1")
+    assert m is not None
+    assert m.a_item_id == "a1"
+
+    assert ops.get_mapping_by_identity(session, pair.id, "nonexistent") is None
+
+
+def test_heal_mapping_ids_updates_provider_ids(session):
+    pair = ops.get_or_create_pair(
+        session, "calendar_event", "a", "ca", "b", "cb", "calname"
+    )
+    m = ops.create_mapping(
+        session, pair.id, "old-a", "old-b", identity_key="k1",
+        fingerprint_a="fpa", fingerprint_b="fpb",
+    )
+    session.flush()
+
+    ops.heal_mapping_ids(session, m, "new-a", "new-b")
+    assert m.a_item_id == "new-a"
+    assert m.b_item_id == "new-b"
+
+
+def test_cache_rebuild_on_schema_version_mismatch(tmp_path):
+    """Simulate an older schema by stamping a different version, then
+    re-opening the DB. Mappings should be cleared; NodePairs should
+    survive."""
+    db_path = tmp_path / "old.db"
+
+    # First session: populate
+    sf = make_session_factory(f"sqlite:///{db_path}")
+    s = sf()
+    pair = ops.get_or_create_pair(
+        s, "calendar_event", "a", "ca", "b", "cb", "calname"
+    )
+    ops.create_mapping(
+        s, pair.id, "a1", "b1", identity_key="k1",
+        fingerprint_a="fpa", fingerprint_b="fpb",
+    )
+    s.commit()
+    # Pretend this DB was stamped with an older version
+    s.execute(text("UPDATE schema_meta SET version = '0-legacy'"))
+    s.commit()
+    s.close()
+
+    # Second session: factory should detect mismatch and rebuild mappings
+    sf2 = make_session_factory(f"sqlite:///{db_path}")
+    s2 = sf2()
+    mappings = s2.query(ItemMapping).all()
+    assert mappings == [], "mappings should be rebuilt on version mismatch"
+    pairs = s2.query(NodePair).all()
+    assert len(pairs) == 1, "NodePairs should survive"
+    row = s2.execute(text("SELECT version FROM schema_meta")).first()
+    assert row[0] == SCHEMA_VERSION
+    s2.close()

--- a/tests/test_state_ops_identity.py
+++ b/tests/test_state_ops_identity.py
@@ -134,6 +134,67 @@ def test_cache_rebuild_on_schema_version_mismatch(tmp_path):
     s2.close()
 
 
+def test_upgrade_when_schema_meta_stamped_but_column_missing(tmp_path):
+    """Real-world case: an earlier run of the buggy migration stamped
+    schema_meta with the current version without actually adding the
+    identity_key column. The factory must not trust the stamp alone —
+    it must inspect the physical table shape.
+    """
+    from sqlalchemy import create_engine
+    db_path = tmp_path / "lying-stamp.db"
+    legacy_url = f"sqlite:///{db_path}"
+
+    engine = create_engine(legacy_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE node_pair (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                item_type VARCHAR(50) NOT NULL,
+                a_provider VARCHAR(100) NOT NULL,
+                a_node_id VARCHAR(255) NOT NULL,
+                b_provider VARCHAR(100) NOT NULL,
+                b_node_id VARCHAR(255) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                merkle_hash VARCHAR(64)
+            )
+        """))
+        # Legacy item_mapping: no identity_key column
+        conn.execute(text("""
+            CREATE TABLE item_mapping (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                pair_id INTEGER NOT NULL,
+                a_item_id VARCHAR(255) NOT NULL,
+                b_item_id VARCHAR(255) NOT NULL,
+                fingerprint_a VARCHAR(255),
+                fingerprint_b VARCHAR(255)
+            )
+        """))
+        # schema_meta stamped with the CURRENT version — this is the lie
+        conn.execute(text("""
+            CREATE TABLE schema_meta (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                version VARCHAR(64) NOT NULL
+            )
+        """))
+        conn.execute(
+            text("INSERT INTO schema_meta (version) VALUES (:v)"),
+            {"v": SCHEMA_VERSION},
+        )
+    engine.dispose()
+
+    sf = make_session_factory(legacy_url)
+    s = sf()
+
+    cols = {
+        row[1]
+        for row in s.execute(text("PRAGMA table_info(item_mapping)")).fetchall()
+    }
+    assert "identity_key" in cols, (
+        "stale schema: factory trusted the lying version stamp"
+    )
+    s.close()
+
+
 def test_upgrade_from_pre_versioning_db_drops_old_item_mapping(tmp_path):
     """Reproduces the field bug: a pre-IP-3 DB has an item_mapping table
     without an identity_key column and no schema_meta table. The factory

--- a/tests/test_state_ops_identity.py
+++ b/tests/test_state_ops_identity.py
@@ -6,9 +6,9 @@ from sqlalchemy import text
 
 from groupware_sync.state import ops
 from groupware_sync.state.db import (
+    SCHEMA_VERSION,
     ItemMapping,
     NodePair,
-    SCHEMA_VERSION,
     make_session_factory,
 )
 

--- a/tests/test_state_ops_identity.py
+++ b/tests/test_state_ops_identity.py
@@ -132,3 +132,73 @@ def test_cache_rebuild_on_schema_version_mismatch(tmp_path):
     row = s2.execute(text("SELECT version FROM schema_meta")).first()
     assert row[0] == SCHEMA_VERSION
     s2.close()
+
+
+def test_upgrade_from_pre_versioning_db_drops_old_item_mapping(tmp_path):
+    """Reproduces the field bug: a pre-IP-3 DB has an item_mapping table
+    without an identity_key column and no schema_meta table. The factory
+    must drop + recreate the cache tables so the new column exists.
+    """
+    from sqlalchemy import create_engine
+    db_path = tmp_path / "legacy.db"
+    legacy_url = f"sqlite:///{db_path}"
+
+    # Build the pre-IP-3 shape: node_pair + the old item_mapping (no identity_key)
+    # + item_snapshot + sync_cursor. No schema_meta table.
+    engine = create_engine(legacy_url, future=True)
+    with engine.begin() as conn:
+        conn.execute(text("""
+            CREATE TABLE node_pair (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                item_type VARCHAR(50) NOT NULL,
+                a_provider VARCHAR(100) NOT NULL,
+                a_node_id VARCHAR(255) NOT NULL,
+                b_provider VARCHAR(100) NOT NULL,
+                b_node_id VARCHAR(255) NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                merkle_hash VARCHAR(64)
+            )
+        """))
+        conn.execute(text("""
+            CREATE TABLE item_mapping (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                pair_id INTEGER NOT NULL,
+                a_item_id VARCHAR(255) NOT NULL,
+                b_item_id VARCHAR(255) NOT NULL,
+                fingerprint_a VARCHAR(255),
+                fingerprint_b VARCHAR(255),
+                FOREIGN KEY(pair_id) REFERENCES node_pair(id)
+            )
+        """))
+        conn.execute(text("""
+            INSERT INTO node_pair
+                (item_type, a_provider, a_node_id, b_provider, b_node_id, name)
+            VALUES ('calendar_event', 'a', 'ca', 'b', 'cb', 'calname')
+        """))
+        conn.execute(text("""
+            INSERT INTO item_mapping
+                (pair_id, a_item_id, b_item_id, fingerprint_a, fingerprint_b)
+            VALUES (1, 'old-a', 'old-b', 'fpa', 'fpb')
+        """))
+    engine.dispose()
+
+    # Open with the real factory — this must not crash, and the column must exist
+    sf = make_session_factory(legacy_url)
+    s = sf()
+
+    cols = {
+        row[1]
+        for row in s.execute(text("PRAGMA table_info(item_mapping)")).fetchall()
+    }
+    assert "identity_key" in cols, (
+        "identity_key column missing — factory didn't migrate the legacy table"
+    )
+
+    # Cache rebuilt — no mappings
+    assert s.query(ItemMapping).all() == []
+    # Structural data (NodePairs) preserved
+    assert len(s.query(NodePair).all()) == 1
+    # Schema stamped
+    version_row = s.execute(text("SELECT version FROM schema_meta")).first()
+    assert version_row[0] == SCHEMA_VERSION
+    s.close()

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -60,7 +60,7 @@ def test_identical_trees_produce_skip(session):
     # Second sync: stored state matches → should prune
     tree_a2 = _make_tree({"contacts": [("c1", "fp1"), ("c2", "fp2")]})
     tree_b2 = _make_tree({"contacts": [("c1", "fp1"), ("c2", "fp2")]})
-    ops_list2 = compare_trees(tree_a2, tree_b2, "prov_a", "prov_b", ItemType.CONTACT, session)
+    ops_list2, _ = compare_trees(tree_a2, tree_b2, "prov_a", "prov_b", ItemType.CONTACT, session)
 
     skip_ops = [op for op in ops_list2 if op.op_type == OpType.SKIP_SUBTREE]
     assert len(skip_ops) > 0
@@ -71,7 +71,7 @@ def test_new_leaf_on_a_creates_on_b(session):
     tree_a = _make_tree({"contacts": [("c1", "fp1"), ("c2", "fp2")]})
     tree_b = _make_tree({"contacts": [("c1", "fp1")]})
 
-    ops_list = compare_trees(tree_a, tree_b, "prov_a", "prov_b", ItemType.CONTACT, session)
+    ops_list, _ = compare_trees(tree_a, tree_b, "prov_a", "prov_b", ItemType.CONTACT, session)
     creates = [op for op in ops_list if op.op_type == OpType.CREATE_ITEM and op.target_side == "b"]
     assert any(op.node_id == "c2" for op in creates)
 
@@ -80,7 +80,7 @@ def test_new_leaf_on_b_creates_on_a(session):
     tree_a = _make_tree({"contacts": [("c1", "fp1")]})
     tree_b = _make_tree({"contacts": [("c1", "fp1"), ("c2", "fp2")]})
 
-    ops_list = compare_trees(tree_a, tree_b, "prov_a", "prov_b", ItemType.CONTACT, session)
+    ops_list, _ = compare_trees(tree_a, tree_b, "prov_a", "prov_b", ItemType.CONTACT, session)
     creates = [op for op in ops_list if op.op_type == OpType.CREATE_ITEM and op.target_side == "a"]
     assert any(op.node_id == "c2" for op in creates)
 
@@ -97,7 +97,7 @@ def test_deleted_on_a_deletes_on_b(session):
     # Second sync: c2 gone from A
     tree_a2 = _make_tree({"contacts": [("c1", "fp1")]})
     tree_b2 = _make_tree({"contacts": [("c1", "fp1"), ("c2", "fp2")]})
-    ops2 = compare_trees(tree_a2, tree_b2, "prov_a", "prov_b", ItemType.CONTACT, session)
+    ops2, _ = compare_trees(tree_a2, tree_b2, "prov_a", "prov_b", ItemType.CONTACT, session)
 
     deletes = [op for op in ops2 if op.op_type == OpType.DELETE_ITEM]
     assert any(op.target_side == "b" for op in deletes)
@@ -115,7 +115,7 @@ def test_fingerprint_change_triggers_merge(session):
     # Second sync: c1 fingerprint changed on A
     tree_a2 = _make_tree({"contacts": [("c1", "fp1_changed")]})
     tree_b2 = _make_tree({"contacts": [("c1", "fp1")]})
-    ops2 = compare_trees(tree_a2, tree_b2, "prov_a", "prov_b", ItemType.CONTACT, session)
+    ops2, _ = compare_trees(tree_a2, tree_b2, "prov_a", "prov_b", ItemType.CONTACT, session)
 
     merges = [op for op in ops2 if op.op_type == OpType.MERGE_ITEM]
     assert len(merges) == 1
@@ -126,7 +126,7 @@ def test_new_container_on_a_creates_on_b(session):
     tree_a = _make_tree({"contacts": [("c1", "fp1")], "work": [("c2", "fp2")]})
     tree_b = _make_tree({"contacts": [("c1", "fp1")]})
 
-    ops_list = compare_trees(tree_a, tree_b, "prov_a", "prov_b", ItemType.CONTACT, session)
+    ops_list, _ = compare_trees(tree_a, tree_b, "prov_a", "prov_b", ItemType.CONTACT, session)
     container_creates = [op for op in ops_list if op.op_type == OpType.CREATE_CONTAINER]
     assert any(op.target_side == "b" for op in container_creates)
 
@@ -140,6 +140,6 @@ def test_both_deleted_cleans_up(session):
 
     tree_a2 = _make_tree({"contacts": []})
     tree_b2 = _make_tree({"contacts": []})
-    ops2 = compare_trees(tree_a2, tree_b2, "prov_a", "prov_b", ItemType.CONTACT, session)
+    ops2, _ = compare_trees(tree_a2, tree_b2, "prov_a", "prov_b", ItemType.CONTACT, session)
     deletes = [op for op in ops2 if op.op_type == OpType.DELETE_ITEM and op.target_side == "both"]
     assert len(deletes) == 1

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -25,11 +25,19 @@ def session():
 
 
 def _make_tree(containers: dict[str, list[tuple[str, str]]]) -> SyncNode:
-    """Helper: build a root with named containers, each with (id, fingerprint) leaves."""
+    """Helper: build a root with named containers, each with (id, fingerprint) leaves.
+
+    identity_key is derived from the leaf id so identity-based pairing works
+    on initial sync with identical IDs on both sides.
+    """
     children = []
     for cname, leaves in containers.items():
         leaf_nodes = [
-            SyncNode(lid, lid, NodeType.LEAF, fingerprint=fp, item_type=ItemType.CONTACT)
+            SyncNode(
+                lid, lid, NodeType.LEAF, fingerprint=fp,
+                identity_key=f"ik:{lid}",
+                item_type=ItemType.CONTACT,
+            )
             for lid, fp in leaves
         ]
         children.append(

--- a/tests/test_tree_identity_pairing.py
+++ b/tests/test_tree_identity_pairing.py
@@ -1,0 +1,184 @@
+"""Identity-based leaf pairing in compare_trees."""
+from __future__ import annotations
+
+import pytest
+
+from groupware_sync.models import (
+    ItemType,
+    NodeType,
+    OpType,
+    SyncNode,
+)
+from groupware_sync.state import ops
+from groupware_sync.state.db import make_session_factory
+from groupware_sync.tree import compare_trees
+
+
+@pytest.fixture
+def session(tmp_path):
+    db_path = tmp_path / "tree.db"
+    sf = make_session_factory(f"sqlite:///{db_path}")
+    s = sf()
+    yield s
+    s.close()
+
+
+def _make_tree(leaves: list[tuple[str, str, str | None]]) -> SyncNode:
+    """leaves: list of (node_id, fingerprint, identity_key)."""
+    leaf_nodes = [
+        SyncNode(
+            lid, lid, NodeType.LEAF, fingerprint=fp, identity_key=ik,
+            item_type=ItemType.CALENDAR_EVENT,
+        )
+        for lid, fp, ik in leaves
+    ]
+    container = SyncNode("c1", "c1", NodeType.CONTAINER, children=leaf_nodes)
+    root = SyncNode("root", "root", NodeType.CONTAINER, children=[container])
+    root.compute_merkle()
+    return root
+
+
+def _pair(s, a_provider="a", b_provider="b"):
+    return ops.get_or_create_pair(
+        s, ItemType.CALENDAR_EVENT.value, a_provider, "c1", b_provider, "c1", "c1"
+    )
+
+
+def test_matched_identity_no_cache_creates_mapping_no_op(session):
+    """First sync: identity matches on both sides → create mapping, no item ops."""
+    a = _make_tree([("a1", "fpa", "k1")])
+    b = _make_tree([("b1", "fpb", "k1")])
+    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+
+    item_ops = [o for o in ops_list
+                if o.op_type in (OpType.CREATE_ITEM, OpType.DELETE_ITEM,
+                                 OpType.MERGE_ITEM)]
+    assert item_ops == [], f"unexpected ops: {item_ops!r}"
+
+    pair = _pair(session)
+    m = ops.get_mapping_by_identity(session, pair.id, "k1")
+    assert m is not None
+    assert m.a_item_id == "a1"
+    assert m.b_item_id == "b1"
+
+
+def test_matched_identity_fingerprint_changed_merges(session):
+    """Cache exists, same identity, one fingerprint drifted → MERGE_ITEM."""
+    pair = _pair(session)
+    ops.create_mapping(
+        session, pair.id, "a1", "b1", identity_key="k1",
+        fingerprint_a="fpa-old", fingerprint_b="fpb-old",
+    )
+    session.flush()
+
+    a = _make_tree([("a1", "fpa-new", "k1")])
+    b = _make_tree([("b1", "fpb-old", "k1")])
+    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    merges = [o for o in ops_list if o.op_type == OpType.MERGE_ITEM]
+    assert len(merges) == 1
+    assert merges[0].identity_key == "k1"
+
+
+def test_mapping_ids_healed_on_drift(session):
+    """Cache has stale provider IDs; new tree has the same identity with
+    different IDs. Mapping is healed silently (no op)."""
+    pair = _pair(session)
+    ops.create_mapping(
+        session, pair.id, "old-a", "old-b", identity_key="k1",
+        fingerprint_a="fpa", fingerprint_b="fpb",
+    )
+    session.flush()
+
+    a = _make_tree([("new-a", "fpa", "k1")])
+    b = _make_tree([("new-b", "fpb", "k1")])
+    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    item_ops = [o for o in ops_list if o.op_type in
+                (OpType.DELETE_ITEM, OpType.CREATE_ITEM, OpType.MERGE_ITEM)]
+    assert item_ops == []
+
+    healed = ops.get_mapping_by_identity(session, pair.id, "k1")
+    assert healed.a_item_id == "new-a"
+    assert healed.b_item_id == "new-b"
+
+
+def test_identity_only_on_a_no_cache_creates_on_b(session):
+    """No cache, item only on A → CREATE on B."""
+    a = _make_tree([("a1", "fpa", "k1")])
+    b = _make_tree([])
+    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    creates = [o for o in ops_list if o.op_type == OpType.CREATE_ITEM]
+    assert len(creates) == 1
+    assert creates[0].target_side == "b"
+    assert creates[0].identity_key == "k1"
+
+
+def test_identity_only_on_a_with_cache_deletes_on_a(session):
+    """Cache has the pair, item disappeared from B → DELETE on A."""
+    pair = _pair(session)
+    ops.create_mapping(
+        session, pair.id, "a1", "b1", identity_key="k1",
+        fingerprint_a="fpa", fingerprint_b="fpb",
+    )
+    session.flush()
+
+    a = _make_tree([("a1", "fpa", "k1")])
+    b = _make_tree([])  # gone from B
+    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    deletes = [o for o in ops_list if o.op_type == OpType.DELETE_ITEM]
+    assert len(deletes) == 1
+    assert deletes[0].target_side == "a"
+
+
+def test_safety_invariant_suppresses_deletes_on_empty_cache(session):
+    """First sync (no cache) must never emit DELETE_ITEM even if state
+    suggests items vanished from one side. Protects against the 2026-04-16
+    cascade after cache loss or schema rebuild."""
+    # No cache entries exist.
+    a = _make_tree([("a1", "fpa", "k1"), ("a2", "fpa", "k2")])
+    b = _make_tree([("b1", "fpb", "k1")])  # k2 not yet on B
+
+    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    deletes = [o for o in ops_list if o.op_type == OpType.DELETE_ITEM]
+    assert deletes == [], f"safety invariant violated: {deletes!r}"
+
+    # Normal creates still happen for the unpaired item
+    creates = [o for o in ops_list if o.op_type == OpType.CREATE_ITEM]
+    assert len(creates) == 1
+    assert creates[0].identity_key == "k2"
+
+
+def test_both_gone_emits_cleanup_delete(session):
+    """Cache has the pair, item gone from both sides → both-gone cleanup."""
+    pair = _pair(session)
+    ops.create_mapping(
+        session, pair.id, "a1", "b1", identity_key="k1",
+        fingerprint_a="fpa", fingerprint_b="fpb",
+    )
+    session.flush()
+
+    a = _make_tree([])
+    b = _make_tree([])
+    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    both_gone = [o for o in ops_list if o.op_type == OpType.DELETE_ITEM
+                 and o.target_side == "both"]
+    assert len(both_gone) == 1
+
+
+def test_unpairable_leaf_creates_on_other_side(session):
+    """Leaf with identity_key=None falls back to unconditional create."""
+    # Prior cache so the safety invariant doesn't strip anything
+    pair = _pair(session)
+    ops.create_mapping(
+        session, pair.id, "a0", "b0", identity_key="k0",
+        fingerprint_a="fpa", fingerprint_b="fpb",
+    )
+    session.flush()
+
+    a = _make_tree([("a0", "fpa", "k0"), ("aX", "fp", None)])  # aX has no id key
+    b = _make_tree([("b0", "fpb", "k0")])
+    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    creates = [o for o in ops_list if o.op_type == OpType.CREATE_ITEM]
+    assert len(creates) == 1
+    assert creates[0].node_id == "aX"
+    assert creates[0].target_side == "b"
+    assert creates[0].identity_key is None

--- a/tests/test_tree_identity_pairing.py
+++ b/tests/test_tree_identity_pairing.py
@@ -48,7 +48,7 @@ def test_matched_identity_no_cache_creates_mapping_no_op(session):
     """First sync: identity matches on both sides → create mapping, no item ops."""
     a = _make_tree([("a1", "fpa", "k1")])
     b = _make_tree([("b1", "fpb", "k1")])
-    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    ops_list, _ = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
 
     item_ops = [o for o in ops_list
                 if o.op_type in (OpType.CREATE_ITEM, OpType.DELETE_ITEM,
@@ -73,7 +73,7 @@ def test_matched_identity_fingerprint_changed_merges(session):
 
     a = _make_tree([("a1", "fpa-new", "k1")])
     b = _make_tree([("b1", "fpb-old", "k1")])
-    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    ops_list, _ = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
     merges = [o for o in ops_list if o.op_type == OpType.MERGE_ITEM]
     assert len(merges) == 1
     assert merges[0].identity_key == "k1"
@@ -91,7 +91,7 @@ def test_mapping_ids_healed_on_drift(session):
 
     a = _make_tree([("new-a", "fpa", "k1")])
     b = _make_tree([("new-b", "fpb", "k1")])
-    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    ops_list, _ = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
     item_ops = [o for o in ops_list if o.op_type in
                 (OpType.DELETE_ITEM, OpType.CREATE_ITEM, OpType.MERGE_ITEM)]
     assert item_ops == []
@@ -105,7 +105,7 @@ def test_identity_only_on_a_no_cache_creates_on_b(session):
     """No cache, item only on A → CREATE on B."""
     a = _make_tree([("a1", "fpa", "k1")])
     b = _make_tree([])
-    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    ops_list, _ = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
     creates = [o for o in ops_list if o.op_type == OpType.CREATE_ITEM]
     assert len(creates) == 1
     assert creates[0].target_side == "b"
@@ -123,7 +123,7 @@ def test_identity_only_on_a_with_cache_deletes_on_a(session):
 
     a = _make_tree([("a1", "fpa", "k1")])
     b = _make_tree([])  # gone from B
-    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    ops_list, _ = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
     deletes = [o for o in ops_list if o.op_type == OpType.DELETE_ITEM]
     assert len(deletes) == 1
     assert deletes[0].target_side == "a"
@@ -137,7 +137,7 @@ def test_safety_invariant_suppresses_deletes_on_empty_cache(session):
     a = _make_tree([("a1", "fpa", "k1"), ("a2", "fpa", "k2")])
     b = _make_tree([("b1", "fpb", "k1")])  # k2 not yet on B
 
-    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    ops_list, _ = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
     deletes = [o for o in ops_list if o.op_type == OpType.DELETE_ITEM]
     assert deletes == [], f"safety invariant violated: {deletes!r}"
 
@@ -158,7 +158,7 @@ def test_both_gone_emits_cleanup_delete(session):
 
     a = _make_tree([])
     b = _make_tree([])
-    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    ops_list, _ = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
     both_gone = [o for o in ops_list if o.op_type == OpType.DELETE_ITEM
                  and o.target_side == "both"]
     assert len(both_gone) == 1
@@ -176,9 +176,31 @@ def test_unpairable_leaf_creates_on_other_side(session):
 
     a = _make_tree([("a0", "fpa", "k0"), ("aX", "fp", None)])  # aX has no id key
     b = _make_tree([("b0", "fpb", "k0")])
-    ops_list = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
+    ops_list, _ = compare_trees(a, b, "a", "b", ItemType.CALENDAR_EVENT, session)
     creates = [o for o in ops_list if o.op_type == OpType.CREATE_ITEM]
     assert len(creates) == 1
     assert creates[0].node_id == "aX"
     assert creates[0].target_side == "b"
     assert creates[0].identity_key is None
+
+
+def test_heal_count_surfaces_via_return(session):
+    """compare_trees returns (ops, healed_count) as a tuple; the engine
+    aggregates the count into SyncSummary.identity_pairs_healed."""
+    pair = _pair(session)
+    ops.create_mapping(
+        session, pair.id, "old-a", "old-b", identity_key="k1",
+        fingerprint_a="fpa", fingerprint_b="fpb",
+    )
+    session.flush()
+
+    a = _make_tree([("new-a", "fpa", "k1")])
+    b = _make_tree([("new-b", "fpb", "k1")])
+    result = compare_trees(
+        a, b, "a", "b", ItemType.CALENDAR_EVENT, session
+    )
+    # Result must be a (ops, healed_count) tuple
+    assert isinstance(result, tuple), "compare_trees must return a tuple"
+    ops_list, healed = result
+    assert healed == 1
+    assert isinstance(ops_list, list)

--- a/tests/test_tree_identity_pairing.py
+++ b/tests/test_tree_identity_pairing.py
@@ -184,6 +184,30 @@ def test_unpairable_leaf_creates_on_other_side(session):
     assert creates[0].identity_key is None
 
 
+def test_duplicate_identity_keys_within_container_demoted_to_unpairable(session):
+    """Two leaves on the same side sharing an identity_key are routed to
+    the unpairable path instead of one silently winning (which would drop
+    the other entirely, missing creates/deletes/merges)."""
+    a = _make_tree([
+        ("a1", "fp1", "dup-key"),
+        ("a2", "fp2", "dup-key"),
+        ("a3", "fp3", "unique-key"),
+    ])
+    b = _make_tree([])
+
+    ops_result, healed = compare_trees(
+        a, b, "a", "b", ItemType.CALENDAR_EVENT, session
+    )
+
+    # No cache, safety invariant suppresses deletes. We expect three
+    # CREATE_ITEMs (both collider leaves + the unique-key one), all
+    # targeting side b.
+    creates = [op for op in ops_result if op.op_type == OpType.CREATE_ITEM]
+    assert {op.node_id for op in creates} == {"a1", "a2", "a3"}
+    assert all(op.target_side == "b" for op in creates)
+    assert healed == 0
+
+
 def test_heal_count_surfaces_via_return(session):
     """compare_trees returns (ops, healed_count) as a tuple; the engine
     aggregates the count into SyncSummary.identity_pairs_healed."""


### PR DESCRIPTION
## Summary

Prevents recurrence of the 2026-04-16 calendar sync incident, where hundreds of Microsoft 365 events were erroneously deleted (with attendee cancellation emails) after Stalwart's provider-side event IDs drifted between syncs. Root cause: items were paired across providers by provider-specific IDs, so when JMAP IDs shifted the comparator concluded the M365-side events had been deleted.

**Fix shape:**
- Pair items across providers by a cross-provider stable identity key (RFC 5545 `UID` ↔ `iCalUId` ↔ JSCalendar `uid`), not provider IDs
- Safety invariant in the tree comparator: no `DELETE_ITEM` ops emitted for a pair on a run with no prior cache entries — protects every first sync and every post-cache-rebuild sync, making delete cascades structurally impossible
- Schema-versioned cache rebuild: on mismatch, the state DB drops every cache table (`item_mapping`, `item_snapshot`, `sync_cursor`, `node_pair`) so no stale half-state can mislead adapters; safety invariant handles the first rebuilt sync
- JMAP calendar adapter: Stalwart rejects `inCalendars` and related filters (`unsupportedFilter`), so the adapter queries events account-wide and buckets by each event's `calendarIds` map client-side, batching `CalendarEvent/get` by the session's `maxObjectsInGet` to avoid `requestTooLarge`
- Observability: CLI summary line now surfaces `healed=N` (mappings silently repaired when provider IDs drift under a stable identity key); tree logs per-pair pairing stats so adapter regressions are visible in the field

**Field validation against the environment that produced yesterday's 942-delete plan:**

```
pair '__synced__': a=943 (keyed=942, unpairable=1), b=833 (keyed=828, unpairable=0),
                   paired_by_identity=766, cache=0
sync: containers=0 created=239 updated=0 deleted=0 conflicts=0 skipped=0 errors=0 healed=0
```

766 events paired silently on a freshly rebuilt cache, zero deletes planned, 239 creates correspond to events that genuinely exist on only one side (176 Stalwart-only + 62 Graph-only + 1 Stalwart event without a UID).

## Scope of changes

- `src/groupware_sync/models.py` — `compute_identity_key`, `SyncNode.identity_key`, `SyncOp.identity_key`, `SyncSummary.identity_pairs_healed`
- `src/groupware_sync/tree.py` — identity-based leaf pairing, per-pair safety invariant, returns `(ops, healed_count)`, per-pair pairing stats log
- `src/groupware_sync/state/db.py` — `identity_key` column, `SchemaMeta`, physical-shape-aware cache-rebuild migration, `SCHEMA_VERSION = 3-rebuild-all`
- `src/groupware_sync/state/ops.py` — `get_mappings_by_identity`, `get_mapping_by_identity`, `heal_mapping_ids`; `create_mapping` requires `identity_key`
- `src/groupware_sync/engine.py` — propagates `identity_key` through executor, tracks heal count into summary
- `src/groupware_sync_calendar/adapters/jmap_adapter.py` — populates `identity_key` from `uid`, drops `inCalendars` filter, buckets by `calendarIds`, chunks `get` by `maxObjectsInGet`
- `src/groupware_sync_calendar/adapters/graph_adapter.py` — populates `identity_key` from `iCalUId`
- `src/groupware_sync_contacts/adapters/*.py` — explicitly set `identity_key=None` (contact identity is a separate follow-up)
- `src/groupware_sync_calendar/cli.py` + `src/groupware_sync_contacts/cli.py` — summary line includes `healed=N`

## Test plan

- [x] `compute_identity_key` unit tests including NFC normalization, casefold (handles German eszett), list-of-dicts shape, empty-input handling
- [x] State DB migration regressions: pre-versioning legacy table, lying version stamp with missing column, version bump drops all cache
- [x] JMAP adapter: account-wide query with no filter, bucketing by `calendarIds`, batching by `maxObjectsInGet`
- [x] Tree comparator: identity pairing, heal-on-drift, safety invariant suppresses deletes when cache is empty
- [x] **Incident regression test** (`tests/test_incident_regression.py`) — reproduces the 2026-04-16 scenario: first sync pairs 100 events by identity, second sync has drifted JMAP IDs, assertion: zero DELETE ops planned, 100 mappings healed
- [x] Full suite: 140 tests pass locally
- [x] Field dry-run against the environment that produced yesterday's 942-delete plan: zero deletes planned (see evidence above)

## Follow-ups (not in this PR)

- Contact identity key (structurally supported now; needs a spec for per-protocol identity field selection)
- Investigate the 239 legitimately-one-sided events — likely recurrence-exception handling differences between JMAP and Graph