### PR TITLE
fix(calendar): normalise Outlook-wrapped GOIDs for identity pairing

### DIFF
--- a/src/groupware_sync_calendar/adapters/caldav_adapter.py
+++ b/src/groupware_sync_calendar/adapters/caldav_adapter.py
@@ -31,6 +31,7 @@ from groupware_sync.provider import (
     SyncProvider,
 )
 from groupware_sync_calendar import tz
+from groupware_sync_calendar.uid_normalize import normalize_outlook_goid
 
 log = logging.getLogger(__name__)
 
@@ -204,7 +205,9 @@ class CalDavCalendarAdapter(SyncProvider):
                 basename = href.rsplit("/", 1)[-1]
                 uid = basename[:-4] if basename.endswith(".ics") else None
                 idk = (
-                    compute_identity_key({"uid": uid}, ["uid"])
+                    compute_identity_key(
+                        {"uid": normalize_outlook_goid(uid)}, ["uid"]
+                    )
                     if uid else None
                 )
                 leaf = SyncNode(

--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -31,6 +31,7 @@ from groupware_sync.provider import (
 )
 from groupware_sync_calendar.rrule import graph_recurrence_to_rrule, rrule_to_graph_recurrence
 from groupware_sync_calendar.tz import from_utc, iana_to_windows, to_utc, windows_to_iana
+from groupware_sync_calendar.uid_normalize import normalize_outlook_goid
 
 log = logging.getLogger(__name__)
 
@@ -253,7 +254,8 @@ class GraphCalendarAdapter(SyncProvider):
                 data = r.json()
                 for event in data.get("value", []):
                     idk = compute_identity_key(
-                        {"uid": event.get("iCalUId")}, ["uid"]
+                        {"uid": normalize_outlook_goid(event.get("iCalUId"))},
+                        ["uid"],
                     )
                     leaf = SyncNode(
                         node_id=event["id"],

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -30,6 +30,7 @@ from groupware_sync.provider import (
     SyncProvider,
 )
 from groupware_sync_calendar import tz
+from groupware_sync_calendar.uid_normalize import normalize_outlook_goid
 
 log = logging.getLogger(__name__)
 
@@ -262,7 +263,8 @@ class JmapCalendarAdapter(SyncProvider):
                         if cal_node is None:
                             continue
                         idk = compute_identity_key(
-                            {"uid": event.get("uid")}, ["uid"]
+                            {"uid": normalize_outlook_goid(event.get("uid"))},
+                            ["uid"],
                         )
                         cal_node.children.append(SyncNode(
                             node_id=event["id"],

--- a/src/groupware_sync_calendar/uid_normalize.py
+++ b/src/groupware_sync_calendar/uid_normalize.py
@@ -11,8 +11,7 @@ of the same event produce different identity keys and fail to pair. This
 module provides one pure function that strips the wrapper when present,
 returning the inner UID, so both sides hash to the same key.
 
-See issue #4 and
-docs:2026-04-23-post-pr2-stalwart-quirks-design.md for background.
+See issue #4 for background.
 """
 from __future__ import annotations
 

--- a/src/groupware_sync_calendar/uid_normalize.py
+++ b/src/groupware_sync_calendar/uid_normalize.py
@@ -1,0 +1,60 @@
+"""UID normalisation for cross-provider calendar identity pairing.
+
+Outlook events carry a GlobalObjectId (GOID) binary blob as their iCalendar
+UID. Microsoft Graph returns the bare inner UID (the iCalendar UID with
+which the event was originally created or imported). Stalwart's JMAP
+CalendarEvent/get returns the full GOID hex, which embeds the inner UID
+inside a ``vCal-Uid\\x01\\x00\\x00\\x00<inner>\\x00`` wrapper.
+
+``compute_identity_key`` hashes raw strings, so these two representations
+of the same event produce different identity keys and fail to pair. This
+module provides one pure function that strips the wrapper when present,
+returning the inner UID, so both sides hash to the same key.
+
+See issue #4 and
+docs:2026-04-23-post-pr2-stalwart-quirks-design.md for background.
+"""
+from __future__ import annotations
+
+# Outlook GlobalObjectId fixed prefix (16 bytes, hex encoded).
+_OUTLOOK_GOID_PREFIX_HEX = "040000008200E00074C5B7101A82E008"
+
+# Byte sequence that marks the start of an embedded iCalendar UID inside
+# a GOID data section. "vCal-Uid" + 0x01 0x00 0x00 0x00.
+_VCAL_UID_MARKER = b"vCal-Uid\x01\x00\x00\x00"
+
+
+def normalize_outlook_goid(uid: str | None) -> str | None:
+    """If *uid* is an Outlook-wrapped GOID, return the embedded inner UID;
+    otherwise return *uid* unchanged.
+
+    Safe fallback: any parsing failure (non-hex content, missing marker,
+    decode error) returns the original input untouched. Callers can always
+    feed the result straight into ``compute_identity_key``.
+    """
+    if not uid:
+        return uid
+
+    if not uid.upper().startswith(_OUTLOOK_GOID_PREFIX_HEX):
+        return uid
+
+    try:
+        raw = bytes.fromhex(uid)
+    except ValueError:
+        return uid
+
+    idx = raw.find(_VCAL_UID_MARKER)
+    if idx == -1:
+        return uid
+
+    inner_bytes = raw[idx + len(_VCAL_UID_MARKER):]
+    # The inner UID is ASCII and terminated by a trailing null byte.
+    # Strip every trailing null defensively.
+    inner_bytes = inner_bytes.rstrip(b"\x00")
+    if not inner_bytes:
+        return uid
+
+    try:
+        return inner_bytes.decode("ascii")
+    except UnicodeDecodeError:
+        return uid

--- a/tests/test_uid_normalize.py
+++ b/tests/test_uid_normalize.py
@@ -1,0 +1,114 @@
+"""Unit tests for normalize_outlook_goid — the pure function that strips
+Outlook's vCal-Uid wrapper from a UID so cross-provider identity pairing
+collides correctly."""
+from __future__ import annotations
+
+from groupware_sync.models import compute_identity_key
+from groupware_sync_calendar.uid_normalize import normalize_outlook_goid
+
+
+# -- Fixture builders -----------------------------------------------------------
+
+OUTLOOK_GOID_PREFIX_HEX = "040000008200E00074C5B7101A82E008"
+# "vCal-Uid\x01\x00\x00\x00" — the inner-UID marker inside a wrapped GOID.
+VCAL_UID_MARKER_HEX = "7643616C2D55696401000000"
+
+
+def _wrap_inner_uid(inner: str) -> str:
+    """Build a realistic hex string that looks like a Stalwart-returned
+    wrapped-GOID: prefix + 28 bytes of filler + vCal-Uid marker + inner UID
+    + trailing null byte."""
+    filler = "00" * 28  # version/flags/date/reserved/size — not inspected
+    inner_hex = inner.encode("ascii").hex().upper()
+    null_hex = "00"
+    return OUTLOOK_GOID_PREFIX_HEX + filler + VCAL_UID_MARKER_HEX + inner_hex + null_hex
+
+
+# -- Falsy / None handling ------------------------------------------------------
+
+def test_none_returned_as_is():
+    assert normalize_outlook_goid(None) is None
+
+
+def test_empty_string_returned_as_is():
+    assert normalize_outlook_goid("") == ""
+
+
+# -- Non-GOID UIDs --------------------------------------------------------------
+
+def test_random_uuid_returned_unchanged():
+    uid = "5f8d1b2a-1234-4321-8abc-deadbeef0001"
+    assert normalize_outlook_goid(uid) == uid
+
+
+def test_google_style_uid_returned_unchanged():
+    uid = "abc123xyz@google.com"
+    assert normalize_outlook_goid(uid) == uid
+
+
+def test_caldav_slug_returned_unchanged():
+    uid = "meeting-2026-04-23-lunch"
+    assert normalize_outlook_goid(uid) == uid
+
+
+# -- Bare GOID (no vCal-Uid marker) ---------------------------------------------
+
+def test_bare_goid_without_marker_returned_unchanged():
+    """A GOID-prefixed string with no vCal-Uid marker — e.g. an Outlook-native
+    event's iCalUId from Graph — must pass through untouched."""
+    bare = OUTLOOK_GOID_PREFIX_HEX + "00" * 40
+    assert normalize_outlook_goid(bare) == bare
+
+
+# -- Wrapped GOID (happy path) --------------------------------------------------
+
+def test_wrapped_goid_yields_inner_uid():
+    inner = "inner-uid-12345"
+    wrapped = _wrap_inner_uid(inner)
+    assert normalize_outlook_goid(wrapped) == inner
+
+
+def test_wrapped_goid_is_case_insensitive_on_prefix():
+    """Stalwart may return the GOID prefix in lowercase; our detection must
+    not be case-sensitive on the hex prefix."""
+    inner = "inner-abc"
+    wrapped = _wrap_inner_uid(inner).lower()
+    assert normalize_outlook_goid(wrapped) == inner
+
+
+# -- Malformed inputs -----------------------------------------------------------
+
+def test_prefix_present_but_no_marker_returned_unchanged():
+    """Some edge GOID blobs might lack the vCal-Uid marker. Graceful fallback
+    — return the raw UID rather than raising."""
+    malformed = OUTLOOK_GOID_PREFIX_HEX + "DEADBEEF" * 10
+    assert normalize_outlook_goid(malformed) == malformed
+
+
+def test_non_hex_input_returned_unchanged():
+    """Defence against totally non-GOID strings that happen to start with
+    the prefix characters — the hex decode should fail gracefully."""
+    # Prefix present but non-hex content after it
+    garbage = OUTLOOK_GOID_PREFIX_HEX + "ZZZZZZZZZZZZZZZZ"
+    assert normalize_outlook_goid(garbage) == garbage
+
+
+# -- The core acceptance: identity-key convergence ------------------------------
+
+def test_graph_and_stalwart_forms_produce_same_identity_key():
+    """The acceptance criterion for issue #4: Graph's bare inner UID and
+    Stalwart's wrapped form of the same event must hash to the same
+    identity_key after normalisation."""
+    inner = "040000008200E00074C5B7101A82E00807000000ABCDEF0123456789"
+    graph_side = inner
+    stalwart_side = _wrap_inner_uid(inner)
+
+    graph_key = compute_identity_key(
+        {"uid": normalize_outlook_goid(graph_side)}, ["uid"]
+    )
+    stalwart_key = compute_identity_key(
+        {"uid": normalize_outlook_goid(stalwart_side)}, ["uid"]
+    )
+
+    assert graph_key is not None
+    assert graph_key == stalwart_key

--- a/tests/test_uid_normalize.py
+++ b/tests/test_uid_normalize.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from groupware_sync.models import compute_identity_key
 from groupware_sync_calendar.uid_normalize import normalize_outlook_goid
 
-
 # -- Fixture builders -----------------------------------------------------------
 
 OUTLOOK_GOID_PREFIX_HEX = "040000008200E00074C5B7101A82E008"


### PR DESCRIPTION
## Summary
- Introduce `normalize_outlook_goid(uid)` — a pure function that strips Stalwart's `vCal-Uid\x01\x00\x00\x00<inner>\x00` wrapper to return the embedded inner UID, with a safe fallback to the raw input on any parse failure.
- Apply the normaliser in all three calendar adapters (JMAP, Graph, CalDAV) immediately before `compute_identity_key`, so Graph's bare iCalUId and Stalwart's wrapped form of the same event hash to the same identity key.

Closes #4.

## Test plan
- [ ] `pytest tests/test_uid_normalize.py -v` — covers None/empty, non-GOID passthrough, wrapped GOID extraction (including lowercase prefix), malformed inputs, and the Graph↔Stalwart identity-key convergence assertion from the issue.
- [ ] `pytest -m "not e2e" -v` — no regressions in the existing calendar / identity / tree / state test suites.
- [ ] Next live Graph↔Stalwart execute: `paired_by_identity` in the tree log should rise from 766 to ~828; the "already exists" error count should drop to zero.