### PR TITLE
feat(calendar): content_key fallback identity for bidirectional pairing

### DIFF
--- a/src/groupware_sync_calendar/adapters/caldav_adapter.py
+++ b/src/groupware_sync_calendar/adapters/caldav_adapter.py
@@ -31,6 +31,7 @@ from groupware_sync.provider import (
     SyncProvider,
 )
 from groupware_sync_calendar import tz
+from groupware_sync_calendar.identity import calendar_content_key
 
 log = logging.getLogger(__name__)
 
@@ -931,6 +932,12 @@ def _ical_to_sync_item(ical_text: str, href: str, etag: str) -> SyncItem:
     # Conference (RFC 7986)
     for conf_prop in event.contents.get("conference", []):
         fields["conference"] = conf_prop.value
+
+    # Secondary identity for execute-time pairing when uid doesn't match
+    # across providers. See src/groupware_sync_calendar/identity.py.
+    ck = calendar_content_key(fields.get("summary"), fields.get("dtstart_utc"))
+    if ck is not None:
+        fields["content_key"] = ck
 
     return SyncItem(
         provider_id=href,

--- a/src/groupware_sync_calendar/adapters/caldav_adapter.py
+++ b/src/groupware_sync_calendar/adapters/caldav_adapter.py
@@ -202,6 +202,16 @@ class CalDavCalendarAdapter(SyncProvider):
                 # widespread CalDAV convention "<UID>.ics" (matches what
                 # our own create_item path writes). Lets CalDAV↔CalDAV
                 # pairs match by RFC 5545 UID like JMAP↔Graph do.
+                #
+                # The JMAP and Graph adapters switched to a content_key
+                # (summary + UTC start) as the primary tree-level
+                # identity because Graph reassigns iCalUId on create.
+                # CalDAV doesn't have that problem (clients own the
+                # UID), and fetching the VEVENT body just to derive
+                # content_key at tree time would be a significant perf
+                # regression. CalDAV↔{JMAP,Graph} divergent-uid cases
+                # are still picked up by the execute-time content_key
+                # fallback listed in CALENDAR_EVENT_SPEC.identity_fields.
                 basename = href.rsplit("/", 1)[-1]
                 uid = basename[:-4] if basename.endswith(".ics") else None
                 idk = (

--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -29,6 +29,7 @@ from groupware_sync.provider import (
     NotificationPolicy,
     SyncProvider,
 )
+from groupware_sync_calendar.identity import calendar_content_key
 from groupware_sync_calendar.rrule import graph_recurrence_to_rrule, rrule_to_graph_recurrence
 from groupware_sync_calendar.tz import from_utc, iana_to_windows, to_utc, windows_to_iana
 
@@ -252,6 +253,16 @@ class GraphCalendarAdapter(SyncProvider):
                 r.raise_for_status()
                 data = r.json()
                 for event in data.get("value", []):
+                    # Graph's iCalUId is server-assigned and read-only —
+                    # values we POST during create are silently replaced.
+                    # Tree-level uid pairing still works for events whose
+                    # iCalUId Stalwart happens to share (because Stalwart
+                    # echoed that iCalUId verbatim on create, or both
+                    # sides received the event from the same external
+                    # ICS source). For Graph-created events the uid
+                    # diverges; CALENDAR_EVENT_SPEC.identity_fields gains
+                    # "content_key" as an execute-time fallback — see
+                    # src/groupware_sync_calendar/identity.py.
                     idk = compute_identity_key(
                         {"uid": event.get("iCalUId")}, ["uid"]
                     )
@@ -527,6 +538,14 @@ def _graph_to_sync_item(event: dict[str, Any]) -> SyncItem:
             )
         except (ValueError, TypeError):
             pass
+
+    # Secondary identity for execute-time pairing when uid doesn't match
+    # across providers. Graph reassigns iCalUId on create (read-only
+    # field), so Stalwart.uid and Graph.iCalUId diverge for events our
+    # sync originated. See src/groupware_sync_calendar/identity.py.
+    ck = calendar_content_key(fields.get("summary"), fields.get("dtstart_utc"))
+    if ck is not None:
+        fields["content_key"] = ck
 
     return SyncItem(
         provider_id=event["id"],

--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -100,6 +100,30 @@ _PARTSTAT_TO_RESPONSE: dict[str, str] = {
 }
 
 
+def _tree_identity_key(event: dict[str, Any]) -> Optional[str]:
+    """Derive a SyncNode.identity_key for a Graph calendar event at
+    tree-build time. Prefers content_key (subject + UTC start) so that
+    events the Graph service created with a freshly-assigned iCalUId
+    still pair with their Stalwart counterpart. Falls back to iCalUId
+    when subject or start is missing from the slim Graph projection.
+    """
+    subject = event.get("subject")
+    start = event.get("start") or {}
+    dt_local = start.get("dateTime")
+    win_tz = start.get("timeZone")
+    dtstart_utc: Optional[str] = None
+    if dt_local and win_tz:
+        try:
+            iana_tz = windows_to_iana(win_tz)
+            dtstart_utc = to_utc(dt_local, iana_tz)
+        except Exception:  # noqa: BLE001
+            dtstart_utc = None
+    ck = calendar_content_key(subject, dtstart_utc)
+    if ck is not None:
+        return compute_identity_key({"content_key": ck}, ["content_key"])
+    return compute_identity_key({"uid": event.get("iCalUId")}, ["uid"])
+
+
 def _priority_to_importance(priority: int) -> str:
     """Map iCalendar priority (0-9) to Graph importance."""
     if priority == 0:
@@ -246,7 +270,8 @@ class GraphCalendarAdapter(SyncProvider):
 
             events_url: Optional[str] = (
                 f"/me/calendars/{cal['id']}/events"
-                f"?$select=id,lastModifiedDateTime,iCalUId&$top=100"
+                f"?$select=id,lastModifiedDateTime,iCalUId,subject,start"
+                f"&$top=100"
             )
             while events_url:
                 r = self._request("GET", events_url)
@@ -255,17 +280,13 @@ class GraphCalendarAdapter(SyncProvider):
                 for event in data.get("value", []):
                     # Graph's iCalUId is server-assigned and read-only —
                     # values we POST during create are silently replaced.
-                    # Tree-level uid pairing still works for events whose
-                    # iCalUId Stalwart happens to share (because Stalwart
-                    # echoed that iCalUId verbatim on create, or both
-                    # sides received the event from the same external
-                    # ICS source). For Graph-created events the uid
-                    # diverges; CALENDAR_EVENT_SPEC.identity_fields gains
-                    # "content_key" as an execute-time fallback — see
+                    # That makes uid unreliable as a cross-provider
+                    # identity. Derive a content_key-based identity from
+                    # subject + UTC start so both sides pair on content
+                    # regardless of what Graph did to the uid. Fall back
+                    # to iCalUId when subject or start is missing. See
                     # src/groupware_sync_calendar/identity.py.
-                    idk = compute_identity_key(
-                        {"uid": event.get("iCalUId")}, ["uid"]
-                    )
+                    idk = _tree_identity_key(event)
                     leaf = SyncNode(
                         node_id=event["id"],
                         name=event["id"],

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -32,6 +32,7 @@ from groupware_sync.provider import (
     SyncProvider,
 )
 from groupware_sync_calendar import tz
+from groupware_sync_calendar.identity import calendar_content_key
 
 log = logging.getLogger(__name__)
 
@@ -1027,6 +1028,13 @@ def _jmap_to_sync_item(event: dict[str, Any]) -> SyncItem:
             updated_at = datetime.fromisoformat(ts.replace("Z", "+00:00"))
         except (ValueError, TypeError):
             pass
+
+    # Secondary identity for execute-time pairing when uid doesn't match
+    # across providers (e.g. Graph-reassigned iCalUId). See
+    # src/groupware_sync_calendar/identity.py.
+    ck = calendar_content_key(fields.get("summary"), fields.get("dtstart_utc"))
+    if ck is not None:
+        fields["content_key"] = ck
 
     return SyncItem(
         provider_id=event.get("id", ""),

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -77,6 +77,29 @@ _RRULE_DAY_TO_JSCAL: dict[str, str] = {v: k for k, v in _JSCAL_DAY_TO_RRULE.item
 _VALID_FREQ = {"YEARLY", "MONTHLY", "WEEKLY", "DAILY", "HOURLY", "MINUTELY", "SECONDLY"}
 
 
+def _tree_identity_key(event: dict[str, Any]) -> Optional[str]:
+    """Derive a SyncNode.identity_key for a JMAP calendar event at tree-build
+    time. Prefers a content_key (title + UTC start) so pairing survives
+    Graph's iCalUId reassignment; falls back to uid when summary or start
+    isn't available.
+    """
+    title = event.get("title")
+    start_str = event.get("start")
+    tz_name = event.get("timeZone")
+    dtstart_utc: Optional[str] = None
+    if start_str and tz_name:
+        try:
+            dtstart_utc = tz.to_utc(start_str, tz_name)
+        except Exception:  # noqa: BLE001
+            dtstart_utc = None
+    elif start_str:
+        dtstart_utc = start_str if start_str.endswith("Z") else start_str + "Z"
+    ck = calendar_content_key(title, dtstart_utc)
+    if ck is not None:
+        return compute_identity_key({"content_key": ck}, ["content_key"])
+    return compute_identity_key({"uid": event.get("uid")}, ["uid"])
+
+
 def _redact_event_payload(event: dict[str, Any]) -> dict[str, Any]:
     """Return a deep copy of *event* with free-text fields redacted.
 
@@ -283,7 +306,11 @@ class JmapCalendarAdapter(SyncProvider):
                     {
                         "accountId": self._account_id,
                         "ids": chunk,
-                        "properties": ["id", "updated", "uid", "calendarIds"],
+                        "properties": [
+                            "id", "updated", "uid", "calendarIds",
+                            # For content_key-based tree identity:
+                            "title", "start", "timeZone",
+                        ],
                     },
                     "g0",
                 ],
@@ -301,9 +328,7 @@ class JmapCalendarAdapter(SyncProvider):
                         cal_node = cal_nodes_by_id.get(cal_id)
                         if cal_node is None:
                             continue
-                        idk = compute_identity_key(
-                            {"uid": event.get("uid")}, ["uid"]
-                        )
+                        idk = _tree_identity_key(event)
                         cal_node.children.append(SyncNode(
                             node_id=event["id"],
                             name=event["id"],

--- a/src/groupware_sync_calendar/identity.py
+++ b/src/groupware_sync_calendar/identity.py
@@ -1,0 +1,43 @@
+"""Content-based fallback identity for calendar events.
+
+Graph's iCalUId is server-assigned and read-only: any value we POST is
+silently replaced. That means ``uid``-based identity pairing (PR #2)
+fails for every event our sync creates on Graph — on the next run,
+Graph.iCalUId != Stalwart.uid and the tree engine sees the two sides
+as orphans.
+
+The engine's ``_identity_match`` (in ``groupware_sync.engine``) already
+has a content-based fallback path used by the contacts type spec. This
+module provides the calendar equivalent: a stable (summary, start-time)
+key used by ``CALENDAR_EVENT_SPEC.identity_fields`` when the uid key
+doesn't match.
+
+See docs:2026-04-24-calendar-content-fallback-pairing-design.md for the
+full rationale and the live-probe evidence.
+"""
+from __future__ import annotations
+
+
+def calendar_content_key(
+    summary: str | None, dtstart_utc: str | None
+) -> str | None:
+    """Return a stable cross-provider identity fallback for a calendar event.
+
+    The key is ``f"{summary.strip().casefold()}|{dtstart_utc}"`` when both
+    inputs are present and non-empty; otherwise ``None``.
+
+    Returns None when either input is missing or whitespace-only. Callers
+    must tolerate a None return (the engine's ``_identity_match`` skips
+    None identity values).
+
+    Note: two distinct events that genuinely share the same title and
+    start-time (e.g. the same "Standup" on the same day in two different
+    calendars) will collide on this key. ``_identity_match`` pairs each
+    item at most once, so collisions degrade to "first pair wins, rest
+    fall through as creates" — no duplicate-pairing regression.
+    """
+    if not summary or not summary.strip():
+        return None
+    if not dtstart_utc:
+        return None
+    return f"{summary.strip().casefold()}|{dtstart_utc}"

--- a/src/groupware_sync_calendar/identity.py
+++ b/src/groupware_sync_calendar/identity.py
@@ -1,19 +1,25 @@
-"""Content-based fallback identity for calendar events.
+"""Content-based identity for calendar events.
 
-Graph's iCalUId is server-assigned and read-only: any value we POST is
-silently replaced. That means ``uid``-based identity pairing (PR #2)
-fails for every event our sync creates on Graph — on the next run,
-Graph.iCalUId != Stalwart.uid and the tree engine sees the two sides
-as orphans.
+Microsoft Graph assigns a fresh ``iCalUId`` to every event created via
+the API (the REST field is documented as read-only; the value a client
+POSTs is silently discarded). A 2026-04-24 round-trip probe confirmed
+this: send ``foo@bar.invalid``, get back a freshly generated GOID.
 
-The engine's ``_identity_match`` (in ``groupware_sync.engine``) already
-has a content-based fallback path used by the contacts type spec. This
-module provides the calendar equivalent: a stable (summary, start-time)
-key used by ``CALENDAR_EVENT_SPEC.identity_fields`` when the uid key
-doesn't match.
+Consequence: ``uid``-based identity pairing (PR #2) cannot match a
+Stalwart-originated event to its Graph counterpart after first sync —
+Stalwart stores the uid we sent, Graph stores its own GOID, and
+``hash(uid_a) != hash(uid_b)``. The tree engine then sees the same
+event as orphans on both sides.
 
-See docs:2026-04-24-calendar-content-fallback-pairing-design.md for the
-full rationale and the live-probe evidence.
+The fix is a cross-provider identity derived from content — title +
+normalised UTC start. Adapters use this as the primary tree-level
+identity when it can be computed, falling back to uid only when
+summary or start is missing. ``CALENDAR_EVENT_SPEC.identity_fields``
+also lists ``content_key`` so the engine's execute-time
+``_identity_match`` catches edge cases where the tree-level fast path
+missed.
+
+See SUNET/groupware-sync PR #9 for the design + live-probe evidence.
 """
 from __future__ import annotations
 

--- a/src/groupware_sync_calendar/specs.py
+++ b/src/groupware_sync_calendar/specs.py
@@ -40,12 +40,14 @@ CALENDAR_EVENT_SPEC = TypeSpec(
         FieldDef("color", MergeStrategy.SCALAR),
         FieldDef("conference", MergeStrategy.SCALAR),
     ],
-    # Tree-level pairing uses "uid". When that fails (e.g. Graph
-    # reassigns iCalUId on create), execute-time _identity_match falls
-    # back to "content_key" — a stable summary+dtstart_utc derivation
-    # populated by each adapter's _*_to_sync_item helper. See
-    # src/groupware_sync_calendar/identity.py and
-    # docs:2026-04-24-calendar-content-fallback-pairing-design.md.
+    # Calendar pairing prefers "content_key" (summary + normalised UTC
+    # start) over "uid" because Graph reassigns iCalUId on create, so
+    # uid cannot anchor a stable cross-provider identity. The JMAP and
+    # Graph adapters compute a content-based SyncNode.identity_key at
+    # tree-build time, falling back to uid only when summary/start are
+    # missing. Execute-time _identity_match also consults both fields
+    # as a belt-and-braces for items the tree layer missed. See
+    # src/groupware_sync_calendar/identity.py.
     identity_fields=["uid", "content_key"],
     timestamp_field="updated",
 )

--- a/src/groupware_sync_calendar/specs.py
+++ b/src/groupware_sync_calendar/specs.py
@@ -40,6 +40,12 @@ CALENDAR_EVENT_SPEC = TypeSpec(
         FieldDef("color", MergeStrategy.SCALAR),
         FieldDef("conference", MergeStrategy.SCALAR),
     ],
-    identity_fields=["uid"],
+    # Tree-level pairing uses "uid". When that fails (e.g. Graph
+    # reassigns iCalUId on create), execute-time _identity_match falls
+    # back to "content_key" — a stable summary+dtstart_utc derivation
+    # populated by each adapter's _*_to_sync_item helper. See
+    # src/groupware_sync_calendar/identity.py and
+    # docs:2026-04-24-calendar-content-fallback-pairing-design.md.
+    identity_fields=["uid", "content_key"],
     timestamp_field="updated",
 )

--- a/tests/test_calendar_content_fallback.py
+++ b/tests/test_calendar_content_fallback.py
@@ -1,0 +1,138 @@
+"""End-to-end check: _identity_match pairs calendar events via content_key
+when uid differs between the two sides.
+
+This is the load-bearing behavioural test for the fallback: it exercises
+CALENDAR_EVENT_SPEC.identity_fields through the real engine helper, not
+a mock."""
+from __future__ import annotations
+
+from groupware_sync.engine import _identity_match
+from groupware_sync.models import ItemType, SyncItem
+from groupware_sync_calendar.specs import CALENDAR_EVENT_SPEC
+
+
+def _event(
+    uid: str,
+    summary: str,
+    dtstart_utc: str,
+    content_key: str | None = None,
+) -> SyncItem:
+    fields: dict = {
+        "uid": uid,
+        "summary": summary,
+        "dtstart_utc": dtstart_utc,
+    }
+    if content_key is not None:
+        fields["content_key"] = content_key
+    return SyncItem(
+        provider_id=uid,
+        item_type=ItemType.CALENDAR_EVENT,
+        fields=fields,
+        fingerprint="",
+    )
+
+
+def test_uid_match_pairs_events():
+    """uid identity still wins at execute time when both sides carry it."""
+    a = _event("abc-123", "Lunch", "2026-05-01T12:00:00Z")
+    b = _event("abc-123", "Lunch", "2026-05-01T12:00:00Z")
+    matched, only_a, only_b = _identity_match(
+        [("a1", a)], [("b1", b)], CALENDAR_EVENT_SPEC
+    )
+    assert len(matched) == 1
+    assert matched[0][0] == "a1"
+    assert matched[0][1] == "b1"
+    assert only_a == []
+    assert only_b == []
+
+
+def test_content_key_match_pairs_events_with_different_uids():
+    """When uid differs but content_key matches, they still pair —
+    the scenario that motivated this PR (Graph-assigned iCalUId vs
+    Stalwart-stored uid for the same event)."""
+    a = _event(
+        "stalwart-uid-xyz",
+        "Lunch",
+        "2026-05-01T12:00:00Z",
+        content_key="lunch|2026-05-01T12:00:00Z",
+    )
+    b = _event(
+        "040000008200E00074C5B7101A82E008-graph-goid",
+        "Lunch",
+        "2026-05-01T12:00:00Z",
+        content_key="lunch|2026-05-01T12:00:00Z",
+    )
+    matched, only_a, only_b = _identity_match(
+        [("a1", a)], [("b1", b)], CALENDAR_EVENT_SPEC
+    )
+    assert len(matched) == 1, f"expected pair, got only_a={only_a} only_b={only_b}"
+    assert matched[0][0] == "a1"
+    assert matched[0][1] == "b1"
+
+
+def test_missing_content_key_does_not_pair_on_different_uids():
+    """If the adapter didn't populate content_key and uids also differ,
+    the two events must not pair."""
+    a = _event("uid-a", "Lunch", "2026-05-01T12:00:00Z")
+    b = _event("uid-b", "Lunch", "2026-05-01T12:00:00Z")
+    matched, only_a, only_b = _identity_match(
+        [("a1", a)], [("b1", b)], CALENDAR_EVENT_SPEC
+    )
+    assert matched == []
+    assert only_a == ["a1"]
+    assert only_b == ["b1"]
+
+
+def test_different_content_key_does_not_pair():
+    """Events with different content (different title or time) do not pair
+    even when both sides have content_key populated."""
+    a = _event(
+        "uid-a",
+        "Lunch",
+        "2026-05-01T12:00:00Z",
+        content_key="lunch|2026-05-01T12:00:00Z",
+    )
+    b = _event(
+        "uid-b",
+        "Dinner",
+        "2026-05-01T18:00:00Z",
+        content_key="dinner|2026-05-01T18:00:00Z",
+    )
+    matched, only_a, only_b = _identity_match(
+        [("a1", a)], [("b1", b)], CALENDAR_EVENT_SPEC
+    )
+    assert matched == []
+    assert only_a == ["a1"]
+    assert only_b == ["b1"]
+
+
+def test_each_item_pairs_at_most_once():
+    """If two A items share a content_key, the first one pairs; the second
+    falls through as only_a. Guarantees no false pair-cloning when genuine
+    duplicates exist on one side."""
+    a1 = _event(
+        "uid-a1",
+        "Lunch",
+        "2026-05-01T12:00:00Z",
+        content_key="lunch|2026-05-01T12:00:00Z",
+    )
+    a2 = _event(
+        "uid-a2",
+        "Lunch",
+        "2026-05-01T12:00:00Z",
+        content_key="lunch|2026-05-01T12:00:00Z",
+    )
+    b = _event(
+        "uid-b",
+        "Lunch",
+        "2026-05-01T12:00:00Z",
+        content_key="lunch|2026-05-01T12:00:00Z",
+    )
+    matched, only_a, only_b = _identity_match(
+        [("a1", a1), ("a2", a2)], [("b1", b)], CALENDAR_EVENT_SPEC
+    )
+    assert len(matched) == 1
+    assert matched[0][0] == "a1"
+    assert matched[0][1] == "b1"
+    assert only_a == ["a2"]
+    assert only_b == []

--- a/tests/test_calendar_content_key.py
+++ b/tests/test_calendar_content_key.py
@@ -1,0 +1,70 @@
+"""Unit tests for calendar_content_key — the pure fallback-identity function.
+
+Returns a stable cross-provider identity key derived from summary +
+dtstart_utc, so the execute-time _identity_match in the sync engine can
+pair calendar events whose uid differs between providers (e.g. when
+Graph has reassigned iCalUId server-side on create)."""
+from __future__ import annotations
+
+from groupware_sync_calendar.identity import calendar_content_key
+
+
+def test_none_summary_returns_none():
+    assert calendar_content_key(None, "2026-05-01T12:00:00Z") is None
+
+
+def test_none_dtstart_returns_none():
+    assert calendar_content_key("Lunch", None) is None
+
+
+def test_empty_summary_returns_none():
+    assert calendar_content_key("", "2026-05-01T12:00:00Z") is None
+
+
+def test_empty_dtstart_returns_none():
+    assert calendar_content_key("Lunch", "") is None
+
+
+def test_whitespace_only_summary_returns_none():
+    assert calendar_content_key("   ", "2026-05-01T12:00:00Z") is None
+
+
+def test_happy_path_returns_lowercase_summary_pipe_dtstart():
+    assert (
+        calendar_content_key("Lunch", "2026-05-01T12:00:00Z")
+        == "lunch|2026-05-01T12:00:00Z"
+    )
+
+
+def test_case_folding_unifies_variants():
+    a = calendar_content_key("Lunch", "2026-05-01T12:00:00Z")
+    b = calendar_content_key("lunch", "2026-05-01T12:00:00Z")
+    c = calendar_content_key("LUNCH", "2026-05-01T12:00:00Z")
+    assert a == b == c
+
+
+def test_surrounding_whitespace_stripped():
+    assert (
+        calendar_content_key("  Lunch  ", "2026-05-01T12:00:00Z")
+        == calendar_content_key("Lunch", "2026-05-01T12:00:00Z")
+    )
+
+
+def test_different_dtstart_produces_different_key():
+    a = calendar_content_key("Lunch", "2026-05-01T12:00:00Z")
+    b = calendar_content_key("Lunch", "2026-05-01T13:00:00Z")
+    assert a != b
+
+
+def test_different_summary_produces_different_key():
+    a = calendar_content_key("Lunch", "2026-05-01T12:00:00Z")
+    b = calendar_content_key("Dinner", "2026-05-01T12:00:00Z")
+    assert a != b
+
+
+def test_german_eszett_casefolds_to_ss():
+    """casefold handles locale-sensitive case where lower() would not.
+    Sanity check of the function's chosen case-folding operation."""
+    a = calendar_content_key("straße", "2026-05-01T12:00:00Z")
+    b = calendar_content_key("STRASSE", "2026-05-01T12:00:00Z")
+    assert a == b

--- a/tests/test_calendar_content_key_adapters.py
+++ b/tests/test_calendar_content_key_adapters.py
@@ -94,7 +94,7 @@ def test_graph_omits_content_key_when_start_missing():
 
 # -- CalDAV --------------------------------------------------------------------
 
-def _ical(summary: str = "Lunch", include_dtstart: bool = True) -> str:
+def _ical(summary: str | None = "Lunch", include_dtstart: bool = True) -> str:
     body = [
         "BEGIN:VCALENDAR",
         "VERSION:2.0",

--- a/tests/test_calendar_content_key_adapters.py
+++ b/tests/test_calendar_content_key_adapters.py
@@ -54,3 +54,41 @@ def test_jmap_populates_content_key_when_timezone_missing():
     item = _jmap_to_sync_item(raw)
     # dtstart_utc gets a trailing Z appended in the no-tz branch.
     assert item.fields.get("content_key") == "lunch|2026-05-01T12:00:00Z"
+
+
+# -- Graph ---------------------------------------------------------------------
+
+from groupware_sync_calendar.adapters.graph_adapter import _graph_to_sync_item  # noqa: E402
+
+
+def test_graph_populates_content_key_when_subject_and_start_present():
+    raw = {
+        "id": "graph-1",
+        "iCalUId": "040000008200E00074C5B7101A82E008...",
+        "subject": "Lunch",
+        "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"},
+        "end":   {"dateTime": "2026-05-01T13:00:00", "timeZone": "UTC"},
+    }
+    item = _graph_to_sync_item(raw)
+    assert item.fields.get("content_key") == "lunch|2026-05-01T12:00:00Z"
+
+
+def test_graph_omits_content_key_when_subject_missing():
+    raw = {
+        "id": "graph-1",
+        "iCalUId": "x",
+        "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"},
+        "end":   {"dateTime": "2026-05-01T13:00:00", "timeZone": "UTC"},
+    }
+    item = _graph_to_sync_item(raw)
+    assert "content_key" not in item.fields
+
+
+def test_graph_omits_content_key_when_start_missing():
+    raw = {
+        "id": "graph-1",
+        "iCalUId": "x",
+        "subject": "Lunch",
+    }
+    item = _graph_to_sync_item(raw)
+    assert "content_key" not in item.fields

--- a/tests/test_calendar_content_key_adapters.py
+++ b/tests/test_calendar_content_key_adapters.py
@@ -2,8 +2,9 @@
 when summary + dtstart_utc are both present, and leaves it absent otherwise."""
 from __future__ import annotations
 
+from groupware_sync_calendar.adapters.caldav_adapter import _ical_to_sync_item
+from groupware_sync_calendar.adapters.graph_adapter import _graph_to_sync_item
 from groupware_sync_calendar.adapters.jmap_adapter import _jmap_to_sync_item
-
 
 # -- JMAP ----------------------------------------------------------------------
 
@@ -58,9 +59,6 @@ def test_jmap_populates_content_key_when_timezone_missing():
 
 # -- Graph ---------------------------------------------------------------------
 
-from groupware_sync_calendar.adapters.graph_adapter import _graph_to_sync_item  # noqa: E402
-
-
 def test_graph_populates_content_key_when_subject_and_start_present():
     raw = {
         "id": "graph-1",
@@ -95,9 +93,6 @@ def test_graph_omits_content_key_when_start_missing():
 
 
 # -- CalDAV --------------------------------------------------------------------
-
-from groupware_sync_calendar.adapters.caldav_adapter import _ical_to_sync_item  # noqa: E402
-
 
 def _ical(summary: str = "Lunch", include_dtstart: bool = True) -> str:
     body = [

--- a/tests/test_calendar_content_key_adapters.py
+++ b/tests/test_calendar_content_key_adapters.py
@@ -39,3 +39,18 @@ def test_jmap_omits_content_key_when_start_missing():
     }
     item = _jmap_to_sync_item(raw)
     assert "content_key" not in item.fields
+
+
+def test_jmap_populates_content_key_when_timezone_missing():
+    """No timeZone → the adapter's no-tz branch must still produce a
+    usable dtstart_utc, and content_key should reflect it. Exercises the
+    path that the other three tests skip."""
+    raw = {
+        "id": "srv-1",
+        "uid": "uid-1",
+        "title": "Lunch",
+        "start": "2026-05-01T12:00:00",
+    }
+    item = _jmap_to_sync_item(raw)
+    # dtstart_utc gets a trailing Z appended in the no-tz branch.
+    assert item.fields.get("content_key") == "lunch|2026-05-01T12:00:00Z"

--- a/tests/test_calendar_content_key_adapters.py
+++ b/tests/test_calendar_content_key_adapters.py
@@ -1,0 +1,41 @@
+"""Per-adapter tests: each _*_to_sync_item populates fields[content_key]
+when summary + dtstart_utc are both present, and leaves it absent otherwise."""
+from __future__ import annotations
+
+from groupware_sync_calendar.adapters.jmap_adapter import _jmap_to_sync_item
+
+
+# -- JMAP ----------------------------------------------------------------------
+
+def test_jmap_populates_content_key_when_summary_and_start_present():
+    raw = {
+        "id": "srv-1",
+        "uid": "uid-1",
+        "title": "Lunch",
+        "start": "2026-05-01T12:00:00",
+        "timeZone": "Etc/UTC",
+        "duration": "PT1H",
+    }
+    item = _jmap_to_sync_item(raw)
+    assert item.fields.get("content_key") == "lunch|2026-05-01T12:00:00Z"
+
+
+def test_jmap_omits_content_key_when_summary_missing():
+    raw = {
+        "id": "srv-1",
+        "uid": "uid-1",
+        "start": "2026-05-01T12:00:00",
+        "timeZone": "Etc/UTC",
+    }
+    item = _jmap_to_sync_item(raw)
+    assert "content_key" not in item.fields
+
+
+def test_jmap_omits_content_key_when_start_missing():
+    raw = {
+        "id": "srv-1",
+        "uid": "uid-1",
+        "title": "Lunch",
+    }
+    item = _jmap_to_sync_item(raw)
+    assert "content_key" not in item.fields

--- a/tests/test_calendar_content_key_adapters.py
+++ b/tests/test_calendar_content_key_adapters.py
@@ -92,3 +92,42 @@ def test_graph_omits_content_key_when_start_missing():
     }
     item = _graph_to_sync_item(raw)
     assert "content_key" not in item.fields
+
+
+# -- CalDAV --------------------------------------------------------------------
+
+from groupware_sync_calendar.adapters.caldav_adapter import _ical_to_sync_item  # noqa: E402
+
+
+def _ical(summary: str = "Lunch", include_dtstart: bool = True) -> str:
+    body = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "BEGIN:VEVENT",
+        "UID:caldav-uid-1",
+    ]
+    if summary is not None:
+        body.append(f"SUMMARY:{summary}")
+    if include_dtstart:
+        body.append("DTSTART:20260501T120000Z")
+        body.append("DTEND:20260501T130000Z")
+    body.append("END:VEVENT")
+    body.append("END:VCALENDAR")
+    return "\r\n".join(body) + "\r\n"
+
+
+def test_caldav_populates_content_key_when_summary_and_start_present():
+    item = _ical_to_sync_item(_ical(), "/cal/abc.ics", "etag-1")
+    assert item.fields.get("content_key") == "lunch|2026-05-01T12:00:00Z"
+
+
+def test_caldav_omits_content_key_when_summary_missing():
+    item = _ical_to_sync_item(_ical(summary=None), "/cal/abc.ics", "etag-1")
+    assert "content_key" not in item.fields
+
+
+def test_caldav_omits_content_key_when_start_missing():
+    item = _ical_to_sync_item(
+        _ical(include_dtstart=False), "/cal/abc.ics", "etag-1"
+    )
+    assert "content_key" not in item.fields

--- a/tests/test_calendar_tree_identity_key.py
+++ b/tests/test_calendar_tree_identity_key.py
@@ -1,0 +1,86 @@
+"""Tree-level identity-key regression: a Stalwart-originated event that was
+synced to Graph (where Graph reassigned iCalUId) must still produce the
+SAME identity_key on both sides at tree-build time.
+
+This is the regression test for the Copilot #1 finding on PR #9:
+without a content-based tree-level identity, the next sync would plan
+DELETE_ITEM target_side='a' on the Stalwart side plus a re-CREATE from
+Graph, losing any user edits and churning the state DB on every run.
+"""
+from __future__ import annotations
+
+from groupware_sync_calendar.adapters.graph_adapter import (
+    _tree_identity_key as graph_tree_identity_key,
+)
+from groupware_sync_calendar.adapters.jmap_adapter import (
+    _tree_identity_key as jmap_tree_identity_key,
+)
+
+
+def test_stalwart_and_graph_pair_by_content_when_uids_diverge():
+    """Stalwart stored the uid we sent; Graph reassigned iCalUId.
+    Both sides must derive the same tree-level identity_key from
+    subject + UTC start."""
+    stalwart_event = {
+        "id": "stalwart-srv-id",
+        "uid": "our-chosen-uid-when-we-created-on-graph",
+        "title": "Design review",
+        "start": "2026-05-01T10:00:00",
+        "timeZone": "Europe/Stockholm",
+        "updated": "2026-05-01T09:00:00Z",
+    }
+    graph_event = {
+        "id": "graph-rest-id",
+        # Fresh GOID that Graph assigned when we POST'd the event —
+        # deliberately different from stalwart_event["uid"] to prove
+        # uid can't anchor the pair.
+        "iCalUId": "040000008200E00074C5B7101A82E008"
+                   "00000000BEEFDEADBEEFDEAD010000"
+                   "00000000000000001000000099F428"
+                   "052CBB324EB74170347B798EA0",
+        "subject": "Design review",
+        "start": {"dateTime": "2026-05-01T10:00:00", "timeZone": "W. Europe Standard Time"},
+        "lastModifiedDateTime": "2026-05-01T09:00:00Z",
+    }
+    stalwart_key = jmap_tree_identity_key(stalwart_event)
+    graph_key = graph_tree_identity_key(graph_event)
+    assert stalwart_key is not None
+    assert graph_key is not None
+    assert stalwart_key == graph_key, (
+        f"tree-level identity_keys must match across providers\n"
+        f"  stalwart: {stalwart_key}\n"
+        f"  graph:    {graph_key}"
+    )
+
+
+def test_jmap_falls_back_to_uid_when_title_or_start_missing():
+    """When content_key can't be derived, the adapter must still produce
+    a stable identity_key from uid — preserving the pre-fix behaviour
+    for events without summary/start."""
+    key_with_uid = jmap_tree_identity_key({"uid": "just-a-uid"})
+    key_with_empty_event = jmap_tree_identity_key({})
+    assert key_with_uid is not None
+    assert key_with_empty_event is None  # compute_identity_key returns None on empty
+
+
+def test_graph_falls_back_to_icaluid_when_subject_or_start_missing():
+    key_with_icaluid = graph_tree_identity_key({"iCalUId": "040000008200E00074C5B7101A82E008ABC"})
+    key_with_empty_event = graph_tree_identity_key({})
+    assert key_with_icaluid is not None
+    assert key_with_empty_event is None
+
+
+def test_different_content_produces_different_identity_key():
+    """Two different real events don't accidentally collide at tree level."""
+    a = jmap_tree_identity_key({
+        "title": "Design review",
+        "start": "2026-05-01T10:00:00",
+        "timeZone": "Etc/UTC",
+    })
+    b = jmap_tree_identity_key({
+        "title": "Retrospective",
+        "start": "2026-05-01T10:00:00",
+        "timeZone": "Etc/UTC",
+    })
+    assert a is not None and b is not None
+    assert a != b


### PR DESCRIPTION
## Summary

- New pure helper `calendar_content_key(summary, dtstart_utc)` in `src/groupware_sync_calendar/identity.py`.
- `CALENDAR_EVENT_SPEC.identity_fields` gains `"content_key"` as a secondary key. Tree-level `uid` pairing stays the fast path; `_identity_match` now has a content-based fallback identical in shape to the one `CONTACT_SPEC.identity_fields = ["emails", "full_name"]` has provided for contacts all along.
- All three calendar adapters (JMAP, Graph, CalDAV) populate `fields["content_key"]` on read when both `summary` and `dtstart_utc` are present.
- Comment at the Graph tree-level `compute_identity_key` call documents the live-probe finding that Graph's `iCalUId` is server-assigned and read-only.

## Why

The 2026-04-24 live probe against `/me/events` confirmed Graph reassigns `iCalUId` on POST (the documented "Read-only" annotation is literal). Stalwart echoes `uid` verbatim. That asymmetry means any event our sync creates on Graph comes back with an `iCalUId` that no longer matches the Stalwart `uid`, and PR #2's identity-key pairing sees the two sides as orphans on every subsequent run — producing a duplicate-creation plan that would grow without bound.

Rather than redesigning pairing, we use the fallback mechanism that `_identity_match` already implements for contacts. A derived `content_key` (`"{summary.casefold()}|{dtstart_utc}"`) is added to `SyncItem.fields`; when uid pairing fails at execute time, the engine now has a second key to try.

This is the correct long-term answer for any new user of the tool — bidirectional sync into Graph cannot rely solely on server-side-assigned identifiers.

Related: #4 is effectively supplanted by this PR — the Outlook-GOID-normalise approach there was reverted in #8 because it was built on a wrong model of the data. This PR is the evidence-based fix.

## Test plan

- [ ] `pytest tests/test_calendar_content_key.py tests/test_calendar_content_fallback.py tests/test_calendar_content_key_adapters.py -v` — unit coverage for the pure helper, end-to-end `_identity_match` behaviour, and all three adapter populations.
- [ ] `pytest -m "not e2e" -v` — no regressions.
- [ ] After merge: wipe the Stalwart calendar, re-sync from Graph, run a second sync, confirm the plan size is near-zero (the empirical check that the fix holds for a fresh account).