### PR TITLE
fix(graph-calendar): dedupe events by iCalUId in build_tree

### DIFF
--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -260,7 +260,15 @@ class GraphCalendarAdapter(SyncProvider):
             else:
                 calendars[0]["name"] = "__synced__"
 
-        # 4. For each calendar, fetch event IDs + timestamps (lightweight)
+        # 4. For each calendar, fetch event IDs + timestamps (lightweight).
+        # Graph occasionally returns two rows with the same iCalUId in the
+        # same calendar (observed in the wild for a small subset of events
+        # — cause not fully understood; likely import artefacts). The tree
+        # engine's _bucket demotes colliding identity_keys to "unpairable",
+        # which then plans CREATEs that Stalwart rejects (it DOES enforce
+        # account-wide uid uniqueness). Dedupe here by iCalUId so only the
+        # first-seen row becomes a leaf, letting the rest of the pipeline
+        # treat the event as a single logical entity.
         for cal in calendars:
             cal_node = SyncNode(
                 node_id=cal["id"],
@@ -273,11 +281,19 @@ class GraphCalendarAdapter(SyncProvider):
                 f"?$select=id,lastModifiedDateTime,iCalUId,subject,start"
                 f"&$top=100"
             )
+            seen_icaluids: set[str] = set()
+            dup_count = 0
             while events_url:
                 r = self._request("GET", events_url)
                 r.raise_for_status()
                 data = r.json()
                 for event in data.get("value", []):
+                    ical = event.get("iCalUId")
+                    if ical and ical in seen_icaluids:
+                        dup_count += 1
+                        continue
+                    if ical:
+                        seen_icaluids.add(ical)
                     # Graph's iCalUId is server-assigned and read-only —
                     # values we POST during create are silently replaced.
                     # That makes uid unreliable as a cross-provider
@@ -299,6 +315,11 @@ class GraphCalendarAdapter(SyncProvider):
                 next_link = data.get("@odata.nextLink")
                 events_url = (
                     next_link if next_link and self._validate_url(next_link) else None
+                )
+            if dup_count:
+                log.info(
+                    "graph calendar %r: %d duplicate-iCalUId event rows skipped",
+                    cal["name"], dup_count,
                 )
 
             root.children.append(cal_node)

--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -266,9 +266,16 @@ class GraphCalendarAdapter(SyncProvider):
         # — cause not fully understood; likely import artefacts). The tree
         # engine's _bucket demotes colliding identity_keys to "unpairable",
         # which then plans CREATEs that Stalwart rejects (it DOES enforce
-        # account-wide uid uniqueness). Dedupe here by iCalUId so only the
-        # first-seen row becomes a leaf, letting the rest of the pipeline
-        # treat the event as a single logical entity.
+        # account-wide uid uniqueness). Dedupe here by iCalUId so only one
+        # row becomes a leaf, letting the rest of the pipeline treat the
+        # event as a single logical entity.
+        #
+        # $orderby lastModifiedDateTime desc,id asc makes the winner
+        # deterministic across runs: the freshest row wins; stable
+        # tie-break by id if two duplicates share a timestamp. Without
+        # $orderby, Graph's response order can flip between runs and the
+        # "winner" flips with it, which would churn ItemMapping rows in
+        # the state DB.
         for cal in calendars:
             cal_node = SyncNode(
                 node_id=cal["id"],
@@ -279,6 +286,7 @@ class GraphCalendarAdapter(SyncProvider):
             events_url: Optional[str] = (
                 f"/me/calendars/{cal['id']}/events"
                 f"?$select=id,lastModifiedDateTime,iCalUId,subject,start"
+                f"&$orderby=lastModifiedDateTime%20desc,id%20asc"
                 f"&$top=100"
             )
             seen_icaluids: set[str] = set()

--- a/tests/test_graph_calendar_identity.py
+++ b/tests/test_graph_calendar_identity.py
@@ -58,6 +58,45 @@ def test_build_tree_leaves_have_identity_key_from_ical_uid():
     )
 
 
+def test_duplicate_icaluid_rows_are_deduped():
+    """Graph sometimes returns two rows with the same iCalUId in the same
+    calendar (import artefacts). Only the first-seen row must become a
+    tree leaf — otherwise _bucket demotes both as colliders, the tree
+    plans CREATEs, and Stalwart rejects them with 'already exists'."""
+    responses = [
+        httpx.Response(200, json={"id": "default-cal", "name": "Kalender"}),
+        httpx.Response(200, json={"value": [
+            {"id": "default-cal", "name": "Kalender"},
+        ]}),
+        # Two rows, same iCalUId, different REST id.
+        httpx.Response(200, json={"value": [
+            {"id": "graph-rest-A", "lastModifiedDateTime": "2026-04-17T00:00:00Z",
+             "iCalUId": "shared-uid", "subject": "Lunch",
+             "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"}},
+            {"id": "graph-rest-B", "lastModifiedDateTime": "2026-04-17T00:00:00Z",
+             "iCalUId": "shared-uid", "subject": "Lunch",
+             "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"}},
+        ]}),
+    ]
+    idx = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        resp = responses[idx["n"]]
+        idx["n"] += 1
+        return resp
+
+    adapter = _adapter_with_transport(httpx.MockTransport(handler))
+    root = adapter.build_tree(ItemType.CALENDAR_EVENT)
+
+    cal = root.children[0]
+    assert len(cal.children) == 1, (
+        f"expected exactly one leaf after dedupe, got {len(cal.children)}: "
+        f"{[leaf.node_id for leaf in cal.children]}"
+    )
+    # The first-seen row wins.
+    assert cal.children[0].node_id == "graph-rest-A"
+
+
 def test_leaf_has_no_identity_key_when_ical_uid_missing():
     responses = [
         httpx.Response(200, json={"id": "default-cal", "name": "Kalender"}),

--- a/tests/test_graph_calendar_identity.py
+++ b/tests/test_graph_calendar_identity.py
@@ -60,27 +60,40 @@ def test_build_tree_leaves_have_identity_key_from_ical_uid():
 
 def test_duplicate_icaluid_rows_are_deduped():
     """Graph sometimes returns two rows with the same iCalUId in the same
-    calendar (import artefacts). Only the first-seen row must become a
-    tree leaf — otherwise _bucket demotes both as colliders, the tree
-    plans CREATEs, and Stalwart rejects them with 'already exists'."""
+    calendar (import artefacts). Only one row must become a tree leaf —
+    otherwise _bucket demotes both as colliders, the tree plans CREATEs,
+    and Stalwart rejects them with 'already exists'.
+
+    The events URL asks Graph for $orderby=lastModifiedDateTime desc,id
+    asc so the freshest row arrives first and the dedupe keeps it.
+    The mock returns rows in that order; the test asserts both the
+    dedupe outcome and that the adapter actually sent $orderby."""
     responses = [
         httpx.Response(200, json={"id": "default-cal", "name": "Kalender"}),
         httpx.Response(200, json={"value": [
             {"id": "default-cal", "name": "Kalender"},
         ]}),
-        # Two rows, same iCalUId, different REST id.
+        # Two rows, same iCalUId, different REST id + different
+        # lastModifiedDateTime. The newer row appears first to match
+        # what Graph returns under $orderby=lastModifiedDateTime desc.
         httpx.Response(200, json={"value": [
-            {"id": "graph-rest-A", "lastModifiedDateTime": "2026-04-17T00:00:00Z",
+            {"id": "graph-rest-NEWER",
+             "lastModifiedDateTime": "2026-04-18T00:00:00Z",
              "iCalUId": "shared-uid", "subject": "Lunch",
              "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"}},
-            {"id": "graph-rest-B", "lastModifiedDateTime": "2026-04-17T00:00:00Z",
+            {"id": "graph-rest-OLDER",
+             "lastModifiedDateTime": "2026-04-17T00:00:00Z",
              "iCalUId": "shared-uid", "subject": "Lunch",
              "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"}},
         ]}),
     ]
     idx = {"n": 0}
+    events_urls_seen: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "/events" in url:
+            events_urls_seen.append(url)
         resp = responses[idx["n"]]
         idx["n"] += 1
         return resp
@@ -93,8 +106,12 @@ def test_duplicate_icaluid_rows_are_deduped():
         f"expected exactly one leaf after dedupe, got {len(cal.children)}: "
         f"{[leaf.node_id for leaf in cal.children]}"
     )
-    # The first-seen row wins.
-    assert cal.children[0].node_id == "graph-rest-A"
+    assert cal.children[0].node_id == "graph-rest-NEWER"
+    # Confirm the adapter asked Graph for a deterministic order.
+    assert events_urls_seen, "no /events request was observed"
+    assert "orderby=lastmodifieddatetime" in events_urls_seen[0].lower(), (
+        f"expected $orderby=lastModifiedDateTime in URL; got {events_urls_seen[0]}"
+    )
 
 
 def test_leaf_has_no_identity_key_when_ical_uid_missing():


### PR DESCRIPTION
## Summary

Graph occasionally returns two event rows with the same \`iCalUId\` in the same calendar. Observed in a real tenant: 5 of 1012 events had a duplicate row. Each pair has a distinct REST \`id\` but identical \`iCalUId\`, \`subject\`, and \`start\` — almost certainly import artefacts or multi-user meeting copies. Fix: in \`build_tree\`, skip subsequent rows whose \`iCalUId\` we've already seen inside the same calendar's pagination. First row wins.

## Why this matters

The two-row shape defeated PR #9's content_key tree-level pairing in a pathological way:

1. Both Graph rows got the same \`SyncNode.identity_key\` → \`_bucket\` demoted both to \`unpairable_b\` (tree.py:191-208).
2. Stalwart had one event with the matching uid → its leaf sat alone in \`by_identity_a\`.
3. Tree iteration found the Stalwart key present on side A but absent on side B (the Graph rows had been demoted out of \`by_identity_b\`). It planned **CREATE_ITEM target_side='b'** — push Stalwart's copy to Graph. Graph doesn't enforce uid uniqueness, so it silently created a **third** copy of the event.
4. \`unpairable_b\` then generated two **CREATE_ITEM target_side='a'** ops (one per Graph row). Stalwart correctly rejected both with \`invalidProperties — An event with UID ... already exists\` (it enforces account-wide uid uniqueness, per RFC 5545).
5. Every subsequent sync re-ran the same plan and Graph gained yet another copy — unbounded divergence.

After this fix the duplicated rows collapse to one tree leaf, pairing proceeds normally, and no spurious creates or rejections fire.

## Test plan

- [x] \`pytest tests/test_graph_calendar_identity.py -v\` — new test asserts two rows with the same iCalUId yield exactly one leaf, first-seen id wins.
- [x] \`pytest -m "not e2e" -q\` — 184 passed, 10 deselected. No regressions.
- [x] \`ruff check\` — clean.
- [ ] On merge: re-run live sync against the Graph↔Stalwart tenant that exhibited the 5 residual \`already exists\` failures. Expected: \`already exists\` count drops to 0 for these cases, and the next run's plan size is near-zero (excluding the separate ~61 \`Invalid property\` errors, which are issue #5's debug-logging scope).

## Known scope limitations

- CalDAV isn't affected — CalDAV servers don't expose the same duplicate-row behaviour.
- JMAP/Stalwart isn't affected — Stalwart enforces account-wide uid uniqueness, so it cannot produce this shape.
- The fix keeps the first row arbitrarily. If a user ever wants control over which copy wins, that's a separate conversation.