### PR TITLE
fix(jmap-calendar): two JSCalendar spec violations in event emitter

### DIFF
--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -1099,11 +1099,20 @@ def _sync_item_to_jmap(item: SyncItem) -> dict[str, Any]:
 
     # Start + duration
     dtstart_utc = fields.get("dtstart_utc")
-    dtstart_tz = fields.get("dtstart_tz", "Etc/UTC")
+    # CalDAV adapter sets dtstart_tz to "" for UTC events and for
+    # all-day events; `.get(key, default)` doesn't substitute on an
+    # explicit empty string, so normalise via `or`.
+    dtstart_tz = fields.get("dtstart_tz") or "Etc/UTC"
     all_day = bool(fields.get("all_day"))
     if dtstart_utc:
-        local_start = tz.from_utc(dtstart_utc, dtstart_tz)
-        event["start"] = local_start
+        # CalDAV all-day events store dtstart_utc as a date-only
+        # ISO string ("YYYY-MM-DD"). tz.from_utc would crash on that
+        # — and JSCalendar wants a LocalDateTime for all-day anyway,
+        # so emit midnight-of-day directly without tz conversion.
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", dtstart_utc):
+            event["start"] = f"{dtstart_utc}T00:00:00"
+        else:
+            event["start"] = tz.from_utc(dtstart_utc, dtstart_tz)
         # JSCalendar RFC 8984 §4.4.1: when showWithoutTime is true,
         # timeZone MUST NOT be set. Stalwart rejects the create
         # otherwise as invalidProperties.

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -799,19 +799,29 @@ def _text_to_jscal_rrule(text: str) -> dict[str, Any]:
         elif key == "COUNT":
             rule["count"] = int(value)
         elif key == "UNTIL":
-            # Reformat to ISO 8601 if needed
+            # JSCalendar RFC 8984 §1.4.6 defines `until` as a
+            # LocalDateTime — YYYY-MM-DDTHH:MM:SS with no zone suffix.
+            # A bare YYYY-MM-DD (what RFC 5545 calls a "date value" for
+            # UNTIL) is NOT acceptable; Stalwart rejects it as
+            # invalidProperties. Coerce to end-of-day so the recurrence
+            # set stays inclusive of the source's last day.
             v = value.strip()
             if len(v) == 8:
-                # YYYYMMDD -> YYYY-MM-DD
-                rule["until"] = f"{v[:4]}-{v[4:6]}-{v[6:8]}"
+                # YYYYMMDD (RFC 5545 date form) -> YYYY-MM-DDT23:59:59
+                rule["until"] = (
+                    f"{v[:4]}-{v[4:6]}-{v[6:8]}T23:59:59"
+                )
             elif "T" in v and len(v) >= 15:
-                # YYYYMMDDTHHMMSS -> YYYY-MM-DDTHH:MM:SS
+                # YYYYMMDDTHHMMSS[Z] -> YYYY-MM-DDTHH:MM:SS
+                # Drop any trailing Z: JSCalendar LocalDateTime is
+                # zoneless; the recurrence is interpreted in the
+                # event's timeZone.
                 d_part = v[:8]
                 t_part = v[9:15] if len(v) >= 15 else v[9:]
-                formatted = f"{d_part[:4]}-{d_part[4:6]}-{d_part[6:8]}T{t_part[:2]}:{t_part[2:4]}:{t_part[4:6]}"
-                if v.endswith("Z"):
-                    formatted += "Z"
-                rule["until"] = formatted
+                rule["until"] = (
+                    f"{d_part[:4]}-{d_part[4:6]}-{d_part[6:8]}"
+                    f"T{t_part[:2]}:{t_part[2:4]}:{t_part[4:6]}"
+                )
             else:
                 rule["until"] = v
         elif key == "BYDAY":
@@ -1090,10 +1100,15 @@ def _sync_item_to_jmap(item: SyncItem) -> dict[str, Any]:
     # Start + duration
     dtstart_utc = fields.get("dtstart_utc")
     dtstart_tz = fields.get("dtstart_tz", "Etc/UTC")
+    all_day = bool(fields.get("all_day"))
     if dtstart_utc:
         local_start = tz.from_utc(dtstart_utc, dtstart_tz)
         event["start"] = local_start
-        event["timeZone"] = dtstart_tz
+        # JSCalendar RFC 8984 §4.4.1: when showWithoutTime is true,
+        # timeZone MUST NOT be set. Stalwart rejects the create
+        # otherwise as invalidProperties.
+        if not all_day:
+            event["timeZone"] = dtstart_tz
 
         # Compute duration from dtend
         dtend_utc = fields.get("dtend_utc")
@@ -1112,7 +1127,7 @@ def _sync_item_to_jmap(item: SyncItem) -> dict[str, Any]:
 
     # All-day
     if fields.get("all_day") is not None:
-        event["showWithoutTime"] = bool(fields["all_day"])
+        event["showWithoutTime"] = all_day
 
     # Location
     if fields.get("location") or fields.get("geo"):

--- a/tests/test_jmap_emitter_jscal_spec_compliance.py
+++ b/tests/test_jmap_emitter_jscal_spec_compliance.py
@@ -97,3 +97,39 @@ def test_all_day_event_without_explicit_flag_defaults_to_timezone_present():
     body = _sync_item_to_jmap(item)
     assert body.get("timeZone") == "Europe/Stockholm"
     assert "showWithoutTime" not in body
+
+
+# -- CalDAV-shaped inputs must not crash the emitter --------------------------
+
+def test_caldav_all_day_shape_date_only_dtstart_empty_tz():
+    """CalDAV adapter emits all-day events with dtstart_utc='YYYY-MM-DD'
+    and dtstart_tz=''. tz.from_utc would crash on both. The emitter
+    must detect the date-only form and emit a JSCalendar-legal payload:
+    LocalDateTime start at midnight, no timeZone, showWithoutTime=true."""
+    item = _item(
+        uid="ev-allday",
+        summary="Semester",
+        dtstart_utc="2021-09-16",
+        dtstart_tz="",
+        all_day=True,
+    )
+    body = _sync_item_to_jmap(item)
+    assert body.get("start") == "2021-09-16T00:00:00"
+    assert body.get("showWithoutTime") is True
+    assert "timeZone" not in body
+
+
+def test_caldav_timed_utc_with_empty_tz_is_coerced_to_etc_utc():
+    """CalDAV adapter can emit UTC events with dtstart_tz=''. The
+    emitter must coerce '' to 'Etc/UTC' rather than feed '' to
+    ZoneInfo (which raises)."""
+    item = _item(
+        uid="ev-utc",
+        summary="Standup",
+        dtstart_utc="2026-05-01T10:00:00Z",
+        dtstart_tz="",
+        all_day=False,
+    )
+    body = _sync_item_to_jmap(item)
+    assert body.get("timeZone") == "Etc/UTC"
+    assert isinstance(body.get("start"), str) and body["start"]

--- a/tests/test_jmap_emitter_jscal_spec_compliance.py
+++ b/tests/test_jmap_emitter_jscal_spec_compliance.py
@@ -1,0 +1,99 @@
+"""JMAP adapter emitter conformance to JSCalendar RFC 8984.
+
+Regression coverage for two bugs Stalwart exposed as
+`invalidProperties — Invalid property.` in the wild:
+
+1. `recurrenceRules[].until` emitted as a bare date (`YYYY-MM-DD`)
+   violates RFC 8984 §1.4.6 — `until` is a `LocalDateTime`.
+2. `timeZone` emitted on all-day events (`showWithoutTime = true`)
+   violates RFC 8984 §4.4.1 — `timeZone MUST NOT be set` in that case.
+"""
+from __future__ import annotations
+
+from groupware_sync.models import ItemType, SyncItem
+from groupware_sync_calendar.adapters.jmap_adapter import (
+    _sync_item_to_jmap,
+    _text_to_jscal_rrule,
+)
+
+# -- Bug A: recurrence UNTIL must be LocalDateTime ----------------------------
+
+def test_rrule_until_date_only_is_coerced_to_local_datetime():
+    """RFC 5545 allows UNTIL=YYYYMMDD; JSCalendar requires a full
+    LocalDateTime. Our emitter must coerce the date form to end-of-day
+    so the recurrence set still includes the source's last day."""
+    rule = _text_to_jscal_rrule("FREQ=WEEKLY;BYDAY=MO;UNTIL=20260629")
+    assert rule["until"] == "2026-06-29T23:59:59"
+
+
+def test_rrule_until_datetime_is_preserved_without_Z_suffix():
+    """UNTIL=YYYYMMDDTHHMMSSZ -> YYYY-MM-DDTHH:MM:SS (no zone suffix).
+    JSCalendar LocalDateTime is zoneless; the event's timeZone governs
+    interpretation."""
+    rule = _text_to_jscal_rrule(
+        "FREQ=WEEKLY;BYDAY=MO;UNTIL=20261221T235959Z"
+    )
+    assert rule["until"] == "2026-12-21T23:59:59"
+
+
+def test_rrule_until_datetime_without_Z_also_preserved():
+    rule = _text_to_jscal_rrule(
+        "FREQ=WEEKLY;BYDAY=MO;UNTIL=20261221T235959"
+    )
+    assert rule["until"] == "2026-12-21T23:59:59"
+
+
+# -- Bug B: all-day events must not carry timeZone ----------------------------
+
+def _item(**fields: object) -> SyncItem:
+    return SyncItem(
+        provider_id="probe",
+        item_type=ItemType.CALENDAR_EVENT,
+        fields=dict(fields),
+        fingerprint="",
+    )
+
+
+def test_all_day_event_omits_timezone():
+    """showWithoutTime=true MUST NOT be accompanied by timeZone."""
+    item = _item(
+        uid="ev-1",
+        summary="Semester",
+        dtstart_utc="2021-09-16T00:00:00Z",
+        dtstart_tz="Etc/UTC",
+        all_day=True,
+    )
+    body = _sync_item_to_jmap(item)
+    assert body.get("showWithoutTime") is True
+    assert "timeZone" not in body, (
+        f"timeZone must be absent for all-day events; got {body.get('timeZone')!r}"
+    )
+    # start is still required, in LocalDateTime form
+    assert body.get("start") == "2021-09-16T00:00:00"
+
+
+def test_timed_event_still_carries_timezone():
+    item = _item(
+        uid="ev-2",
+        summary="Meeting",
+        dtstart_utc="2026-05-01T10:00:00Z",
+        dtstart_tz="Europe/Stockholm",
+        all_day=False,
+    )
+    body = _sync_item_to_jmap(item)
+    assert body.get("timeZone") == "Europe/Stockholm"
+    assert body.get("showWithoutTime") is False
+
+
+def test_all_day_event_without_explicit_flag_defaults_to_timezone_present():
+    """When all_day isn't set in fields, we treat as timed (backwards
+    compatible with older SyncItems that lack the all_day flag)."""
+    item = _item(
+        uid="ev-3",
+        summary="Meeting",
+        dtstart_utc="2026-05-01T10:00:00Z",
+        dtstart_tz="Europe/Stockholm",
+    )
+    body = _sync_item_to_jmap(item)
+    assert body.get("timeZone") == "Europe/Stockholm"
+    assert "showWithoutTime" not in body


### PR DESCRIPTION
## Summary

PR #7's redacted debug logging on a live Stalwart tenant exposed the shape of the 61 \`invalidProperties — Invalid property.\` rejections that had been opaque since the original 2026-04-23 execute. Two concrete, distinct bugs in the Graph→Stalwart emitter — both actual JSCalendar RFC 8984 spec violations:

### Bug A — \`recurrenceRules[].until\` emitted as a bare date

RFC 5545 allows \`UNTIL=YYYYMMDD\` (a date value). RFC 8984 §1.4.6 defines JSCalendar's \`until\` as a **LocalDateTime** — \`YYYY-MM-DDTHH:MM:SS\`. Our \`_text_to_jscal_rrule\` was emitting \`YYYY-MM-DD\` for the date-only case and Stalwart correctly rejected.

Fix: coerce date-form UNTIL to end-of-day (\`T23:59:59\`) so the recurrence set stays inclusive of the source's last day. Also drop any trailing \`Z\` on datetime UNTILs: LocalDateTime is zoneless; the event's \`timeZone\` property governs interpretation.

### Bug B — \`timeZone\` emitted on all-day events

RFC 8984 §4.4.1: when \`showWithoutTime\` is true, \`timeZone MUST NOT be set\`. \`_sync_item_to_jmap\` was unconditionally setting \`timeZone\` whenever \`dtstart_utc\` was populated. Fix: skip \`timeZone\` when the item's \`all_day\` flag is truthy. Timed events still carry it as before.

## Evidence

Four failing payloads captured by the debug log (sample):

| \`recurrenceRules[].until\` | \`showWithoutTime\` | \`timeZone\` |
|---|---|---|
| \`"2026-06-29"\` | false | \`"Etc/UTC"\` |
| *absent* | **true** | **\`"Etc/UTC"\`** |
| \`"2021-12-28"\` | false | \`"Etc/UTC"\` |
| \`"2026-12-22"\` | false | \`"Etc/UTC"\` |

Three of four are Bug A; one is Bug B. Expected field impact on merge: the \`Invalid property\` count drops to zero.

## Scope

- \`_sync_item_to_jmap\` and \`_text_to_jscal_rrule\` only. Reverse direction (\`_jmap_to_sync_item\`, \`_jscal_rrule_to_text\`) is unaffected — the bugs were only in what we write.
- No Graph adapter changes. Graph uses its own recurrence object format and doesn't hit these code paths.
- CalDAV adapter unaffected.

## Test plan

- [x] \`pytest tests/test_jmap_emitter_jscal_spec_compliance.py -v\` — 6 new tests covering both bugs, plus backwards-compat shape for timed events and items without the \`all_day\` flag.
- [x] \`pytest -m "not e2e" -q\` — 189 passed, 10 deselected. No regressions.
- [x] \`ruff check\` — clean.
- [ ] On merge: re-run live Graph↔Stalwart sync. Expected: \`errors\` drops from ~62 toward 0. Combined with PR #10 (iCalUId dedupe), steady state should be reachable.