### PR TITLE
fix(graph-calendar): client-side dedupe sort; drop $orderby

### DIFF
--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -299,28 +299,12 @@ class GraphCalendarAdapter(SyncProvider):
                     next_link if next_link and self._validate_url(next_link) else None
                 )
 
-            # Stable dedupe: freshest (max lastModifiedDateTime) wins;
-            # tie-break by smallest id so the same row wins every run.
-            # Sort descending by (lastModifiedDateTime, -id-as-str) —
-            # easier expressed by sorting ascending on (-lmd, id) then
-            # picking first-seen.
-            all_events.sort(
-                key=lambda ev: (
-                    ev.get("lastModifiedDateTime", ""),
-                    # Invert id order by using the negative of its sort
-                    # position: a larger id sorts after a smaller one
-                    # ascending, so for a DESC outer sort we want the
-                    # smaller id to end up "later" (greater). Python's
-                    # tuple sort doesn't take a per-key direction, so
-                    # just reverse the whole list below.
-                    ev.get("id", ""),
-                ),
-                reverse=True,
-            )
-            # reverse=True gives (lmd desc, id desc) — we wanted id asc
-            # for tie-break. Post-process: for equal lmd, reverse only
-            # the id order among the group by sorting that slice asc.
-            # Simpler: use stable sort twice (Python's sort is stable).
+            # Dedupe winner rule: greatest lastModifiedDateTime wins;
+            # smallest id breaks a timestamp tie. Python's sort is
+            # stable, so sort twice — first by the tie-break key (id
+            # ascending), then by the primary key (lastModifiedDateTime
+            # descending). Entries with equal timestamps retain the
+            # id-ascending order established by the first sort.
             all_events.sort(key=lambda ev: ev.get("id", ""))
             all_events.sort(
                 key=lambda ev: ev.get("lastModifiedDateTime", ""),

--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -270,12 +270,12 @@ class GraphCalendarAdapter(SyncProvider):
         # row becomes a leaf, letting the rest of the pipeline treat the
         # event as a single logical entity.
         #
-        # $orderby lastModifiedDateTime desc,id asc makes the winner
-        # deterministic across runs: the freshest row wins; stable
-        # tie-break by id if two duplicates share a timestamp. Without
-        # $orderby, Graph's response order can flip between runs and the
-        # "winner" flips with it, which would churn ItemMapping rows in
-        # the state DB.
+        # Order is picked client-side: prefer the row with the greatest
+        # lastModifiedDateTime, tie-break by smallest id. We tried
+        # `$orderby=lastModifiedDateTime desc,id asc` on the URL but
+        # Graph responds with 400 Bad Request — `id` isn't an orderable
+        # property on /me/events, and some Graph tenants reject any
+        # $orderby on this endpoint. Client-side sort is bulletproof.
         for cal in calendars:
             cal_node = SyncNode(
                 node_id=cal["id"],
@@ -286,44 +286,74 @@ class GraphCalendarAdapter(SyncProvider):
             events_url: Optional[str] = (
                 f"/me/calendars/{cal['id']}/events"
                 f"?$select=id,lastModifiedDateTime,iCalUId,subject,start"
-                f"&$orderby=lastModifiedDateTime%20desc,id%20asc"
                 f"&$top=100"
             )
-            seen_icaluids: set[str] = set()
-            dup_count = 0
+            all_events: list[dict[str, Any]] = []
             while events_url:
                 r = self._request("GET", events_url)
                 r.raise_for_status()
                 data = r.json()
-                for event in data.get("value", []):
-                    ical = event.get("iCalUId")
-                    if ical and ical in seen_icaluids:
-                        dup_count += 1
-                        continue
-                    if ical:
-                        seen_icaluids.add(ical)
-                    # Graph's iCalUId is server-assigned and read-only —
-                    # values we POST during create are silently replaced.
-                    # That makes uid unreliable as a cross-provider
-                    # identity. Derive a content_key-based identity from
-                    # subject + UTC start so both sides pair on content
-                    # regardless of what Graph did to the uid. Fall back
-                    # to iCalUId when subject or start is missing. See
-                    # src/groupware_sync_calendar/identity.py.
-                    idk = _tree_identity_key(event)
-                    leaf = SyncNode(
-                        node_id=event["id"],
-                        name=event["id"],
-                        node_type=NodeType.LEAF,
-                        fingerprint=event.get("lastModifiedDateTime", ""),
-                        item_type=ItemType.CALENDAR_EVENT,
-                        identity_key=idk,
-                    )
-                    cal_node.children.append(leaf)
+                all_events.extend(data.get("value", []))
                 next_link = data.get("@odata.nextLink")
                 events_url = (
                     next_link if next_link and self._validate_url(next_link) else None
                 )
+
+            # Stable dedupe: freshest (max lastModifiedDateTime) wins;
+            # tie-break by smallest id so the same row wins every run.
+            # Sort descending by (lastModifiedDateTime, -id-as-str) —
+            # easier expressed by sorting ascending on (-lmd, id) then
+            # picking first-seen.
+            all_events.sort(
+                key=lambda ev: (
+                    ev.get("lastModifiedDateTime", ""),
+                    # Invert id order by using the negative of its sort
+                    # position: a larger id sorts after a smaller one
+                    # ascending, so for a DESC outer sort we want the
+                    # smaller id to end up "later" (greater). Python's
+                    # tuple sort doesn't take a per-key direction, so
+                    # just reverse the whole list below.
+                    ev.get("id", ""),
+                ),
+                reverse=True,
+            )
+            # reverse=True gives (lmd desc, id desc) — we wanted id asc
+            # for tie-break. Post-process: for equal lmd, reverse only
+            # the id order among the group by sorting that slice asc.
+            # Simpler: use stable sort twice (Python's sort is stable).
+            all_events.sort(key=lambda ev: ev.get("id", ""))
+            all_events.sort(
+                key=lambda ev: ev.get("lastModifiedDateTime", ""),
+                reverse=True,
+            )
+
+            seen_icaluids: set[str] = set()
+            dup_count = 0
+            for event in all_events:
+                ical = event.get("iCalUId")
+                if ical and ical in seen_icaluids:
+                    dup_count += 1
+                    continue
+                if ical:
+                    seen_icaluids.add(ical)
+                # Graph's iCalUId is server-assigned and read-only —
+                # values we POST during create are silently replaced.
+                # That makes uid unreliable as a cross-provider
+                # identity. Derive a content_key-based identity from
+                # subject + UTC start so both sides pair on content
+                # regardless of what Graph did to the uid. Fall back
+                # to iCalUId when subject or start is missing. See
+                # src/groupware_sync_calendar/identity.py.
+                idk = _tree_identity_key(event)
+                leaf = SyncNode(
+                    node_id=event["id"],
+                    name=event["id"],
+                    node_type=NodeType.LEAF,
+                    fingerprint=event.get("lastModifiedDateTime", ""),
+                    item_type=ItemType.CALENDAR_EVENT,
+                    identity_key=idk,
+                )
+                cal_node.children.append(leaf)
             if dup_count:
                 log.info(
                     "graph calendar %r: %d duplicate-iCalUId event rows skipped",

--- a/tests/test_graph_calendar_identity.py
+++ b/tests/test_graph_calendar_identity.py
@@ -58,31 +58,28 @@ def test_build_tree_leaves_have_identity_key_from_ical_uid():
     )
 
 
-def test_duplicate_icaluid_rows_are_deduped():
+def test_duplicate_icaluid_rows_are_deduped_to_newest():
     """Graph sometimes returns two rows with the same iCalUId in the same
-    calendar (import artefacts). Only one row must become a tree leaf —
-    otherwise _bucket demotes both as colliders, the tree plans CREATEs,
-    and Stalwart rejects them with 'already exists'.
-
-    The events URL asks Graph for $orderby=lastModifiedDateTime desc,id
-    asc so the freshest row arrives first and the dedupe keeps it.
-    The mock returns rows in that order; the test asserts both the
-    dedupe outcome and that the adapter actually sent $orderby."""
+    calendar (import artefacts). Only one row must become a tree leaf
+    and the winner must be deterministic across runs — otherwise state
+    DB mappings churn. Winner rule: greatest lastModifiedDateTime,
+    tie-break by smallest id. Dedupe happens client-side; we do NOT
+    rely on $orderby (Graph rejects compound orderby on /me/events
+    with 400 Bad Request)."""
     responses = [
         httpx.Response(200, json={"id": "default-cal", "name": "Kalender"}),
         httpx.Response(200, json={"value": [
             {"id": "default-cal", "name": "Kalender"},
         ]}),
-        # Two rows, same iCalUId, different REST id + different
-        # lastModifiedDateTime. The newer row appears first to match
-        # what Graph returns under $orderby=lastModifiedDateTime desc.
+        # Return the rows in the WRONG order (oldest first) to prove
+        # the dedupe doesn't depend on Graph's response order.
         httpx.Response(200, json={"value": [
-            {"id": "graph-rest-NEWER",
-             "lastModifiedDateTime": "2026-04-18T00:00:00Z",
-             "iCalUId": "shared-uid", "subject": "Lunch",
-             "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"}},
             {"id": "graph-rest-OLDER",
              "lastModifiedDateTime": "2026-04-17T00:00:00Z",
+             "iCalUId": "shared-uid", "subject": "Lunch",
+             "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"}},
+            {"id": "graph-rest-NEWER",
+             "lastModifiedDateTime": "2026-04-18T00:00:00Z",
              "iCalUId": "shared-uid", "subject": "Lunch",
              "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"}},
         ]}),
@@ -107,11 +104,44 @@ def test_duplicate_icaluid_rows_are_deduped():
         f"{[leaf.node_id for leaf in cal.children]}"
     )
     assert cal.children[0].node_id == "graph-rest-NEWER"
-    # Confirm the adapter asked Graph for a deterministic order.
+    # Confirm we do NOT send $orderby (Graph rejects it with 400).
     assert events_urls_seen, "no /events request was observed"
-    assert "orderby=lastmodifieddatetime" in events_urls_seen[0].lower(), (
-        f"expected $orderby=lastModifiedDateTime in URL; got {events_urls_seen[0]}"
+    assert "orderby" not in events_urls_seen[0].lower(), (
+        f"$orderby must not appear in URL; got {events_urls_seen[0]}"
     )
+
+
+def test_duplicate_icaluid_same_timestamp_tie_breaks_on_smallest_id():
+    """When two duplicate rows share lastModifiedDateTime, the row with
+    the smallest id wins — stable across runs."""
+    responses = [
+        httpx.Response(200, json={"id": "default-cal", "name": "Kalender"}),
+        httpx.Response(200, json={"value": [
+            {"id": "default-cal", "name": "Kalender"},
+        ]}),
+        httpx.Response(200, json={"value": [
+            {"id": "z-graph-rest-BIG",
+             "lastModifiedDateTime": "2026-04-17T00:00:00Z",
+             "iCalUId": "shared-uid", "subject": "Lunch",
+             "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"}},
+            {"id": "a-graph-rest-SMALL",
+             "lastModifiedDateTime": "2026-04-17T00:00:00Z",
+             "iCalUId": "shared-uid", "subject": "Lunch",
+             "start": {"dateTime": "2026-05-01T12:00:00", "timeZone": "UTC"}},
+        ]}),
+    ]
+    idx = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        resp = responses[idx["n"]]
+        idx["n"] += 1
+        return resp
+
+    adapter = _adapter_with_transport(httpx.MockTransport(handler))
+    root = adapter.build_tree(ItemType.CALENDAR_EVENT)
+    cal = root.children[0]
+    assert len(cal.children) == 1
+    assert cal.children[0].node_id == "a-graph-rest-SMALL"
 
 
 def test_leaf_has_no_identity_key_when_ical_uid_missing():


### PR DESCRIPTION
## Summary

\`\$orderby=lastModifiedDateTime%20desc,id%20asc\` (added in #10 to make the Graph duplicate-iCalUId dedupe deterministic) broke the whole sync on a real tenant — Graph responded **400 Bad Request**.

\`\`\`
HTTP/1.1 400 Bad Request
  GET /v1.0/me/calendars/{…}/events?\$select=…&\$orderby=lastModifiedDateTime%20desc,id%20asc&\$top=100
\`\`\`

\`id\` is not an orderable property on \`/me/events\`, and some tenants reject any \`\$orderby\` on this endpoint regardless. The whole \`build_tree\` call errored out before any events were returned.

## Fix

Drop \`\$orderby\` from the URL entirely. Keep the dedupe deterministic by sorting **client-side** after pagination:

1. Fetch all events into a list (paginated via \`\$top=100\` + \`@odata.nextLink\`).
2. Sort stably by \`id asc\`, then again by \`lastModifiedDateTime desc\`. Python's stable sort leaves \`id\` in ascending order within groups that share a \`lastModifiedDateTime\` — the exact winner rule we want.
3. Dedupe by \`iCalUId\`, first-seen wins (= greatest \`lastModifiedDateTime\`, smallest \`id\` on tie).

Net observable behaviour unchanged: freshest row wins, stable tie-break by id, deterministic across runs. But no more 400s.

## Test plan

- [x] \`pytest tests/test_graph_calendar_identity.py -v\` — 4 passes.
  - \`test_duplicate_icaluid_rows_are_deduped_to_newest\` — feeds rows in the wrong order (oldest first) so only the client-side sort picks the newer.
  - \`test_duplicate_icaluid_same_timestamp_tie_breaks_on_smallest_id\` — two rows share \`lastModifiedDateTime\`; smaller id wins.
  - Both also assert the URL has NO \`\$orderby\` parameter.
- [x] \`pytest -m "not e2e" -q\` — 193 passed, no regressions.
- [x] \`ruff check\` — clean.
- [ ] On merge: re-run sync. Expected: no 400s from Graph, errors drop near zero, steady state on second run.