### PR TITLE
fix(jmap-calendar): surface server-side properties list in error messages

### DIFF
--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -100,6 +100,24 @@ def _tree_identity_key(event: dict[str, Any]) -> Optional[str]:
     return compute_identity_key({"uid": event.get("uid")}, ["uid"])
 
 
+def _format_set_error(prefix: str, err: dict[str, Any]) -> str:
+    """Format a JMAP /set error for a human-readable exception message.
+
+    Includes the ``properties`` array when present — some servers (notably
+    Stalwart) return ``invalidProperties`` with description "Invalid
+    property." and put the offending field names in ``properties``. Without
+    surfacing that list, operators have to probe the API to figure out
+    which field the server rejected.
+    """
+    t = err.get("type", "unknown")
+    desc = err.get("description", "")
+    parts = [f"{prefix}: {t} — {desc}"]
+    props = err.get("properties")
+    if props:
+        parts.append(f"(properties: {list(props)})")
+    return " ".join(parts)
+
+
 def _redact_event_payload(event: dict[str, Any]) -> dict[str, Any]:
     """Return a deep copy of *event* with free-text fields redacted.
 
@@ -484,10 +502,9 @@ class JmapCalendarAdapter(SyncProvider):
                             "JMAP create failed — request payload: %s",
                             json.dumps(_redact_event_payload(event), default=repr),
                         )
-                    raise ValueError(
-                        f"JMAP create calendar event failed: "
-                        f"{err.get('type', 'unknown')} — {err.get('description', '')}"
-                    )
+                    raise ValueError(_format_set_error(
+                        "JMAP create calendar event failed", err,
+                    ))
                 created = result[1].get("created", {})
                 new_item = created.get("new1", {})
                 new_id = new_item["id"]

--- a/tests/test_jmap_set_error_formatting.py
+++ b/tests/test_jmap_set_error_formatting.py
@@ -1,0 +1,123 @@
+"""The JMAP /set error formatter must include the `properties` list from
+the server response. Stalwart uses that list to name the offending field
+on `invalidProperties` rejections; without surfacing it, operators have
+to probe the API to figure out which field was rejected (as this project
+did, repeatedly, for `recurrenceRules`)."""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from groupware_sync.models import ItemType, SyncItem
+from groupware_sync_calendar.adapters.jmap_adapter import (
+    JmapCalendarAdapter,
+    _format_set_error,
+)
+
+# -- Helper unit tests --------------------------------------------------------
+
+def test_format_set_error_without_properties():
+    msg = _format_set_error("X", {"type": "invalidProperties", "description": "Invalid property."})
+    assert msg == "X: invalidProperties — Invalid property."
+
+
+def test_format_set_error_with_properties():
+    msg = _format_set_error("X", {
+        "type": "invalidProperties",
+        "description": "Invalid property.",
+        "properties": ["recurrenceRules"],
+    })
+    assert msg == "X: invalidProperties — Invalid property. (properties: ['recurrenceRules'])"
+
+
+def test_format_set_error_multi_property():
+    msg = _format_set_error("X", {
+        "type": "invalidProperties",
+        "description": "Invalid property.",
+        "properties": ["recurrenceRules", "alerts"],
+    })
+    assert "['recurrenceRules', 'alerts']" in msg
+
+
+def test_format_set_error_falsy_properties_is_ignored():
+    msg = _format_set_error("X", {"type": "invalidProperties", "description": "Invalid property.", "properties": []})
+    assert "properties" not in msg
+
+
+def test_format_set_error_missing_type_and_description():
+    msg = _format_set_error("X", {})
+    assert msg == "X: unknown — "
+
+
+# -- Integration: create_item surfaces properties in the ValueError ----------
+
+JMAP_SESSION_PAYLOAD = {
+    "apiUrl": "https://jmap.example.com/api",
+    "accounts": {
+        "acc1": {"accountCapabilities": {"urn:ietf:params:jmap:calendars": {}}},
+    },
+    "primaryAccounts": {"urn:ietf:params:jmap:calendars": "acc1"},
+    "capabilities": {"urn:ietf:params:jmap:core": {"maxObjectsInGet": 100}},
+}
+
+
+def _adapter_with_create_failure(properties: list[str] | None) -> JmapCalendarAdapter:
+    err: dict = {"type": "invalidProperties", "description": "Invalid property."}
+    if properties is not None:
+        err["properties"] = properties
+    responses = [
+        httpx.Response(200, json=JMAP_SESSION_PAYLOAD),
+        httpx.Response(200, json={
+            "methodResponses": [[
+                "CalendarEvent/set",
+                {"notCreated": {"new1": err}},
+                "c0",
+            ]],
+        }),
+    ]
+    idx = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        resp = responses[idx["n"]]
+        idx["n"] += 1
+        return resp
+
+    a = JmapCalendarAdapter("https://jmap.example.com", "tok")
+    a._client = httpx.Client(
+        headers={"Authorization": "Bearer tok"},
+        transport=httpx.MockTransport(handler),
+        timeout=5.0,
+        follow_redirects=True,
+    )
+    return a
+
+
+def _item() -> SyncItem:
+    return SyncItem(
+        provider_id="probe",
+        item_type=ItemType.CALENDAR_EVENT,
+        fields={
+            "uid": "ev-1",
+            "summary": "X",
+            "dtstart_utc": "2030-01-01T09:00:00Z",
+            "dtstart_tz": "Etc/UTC",
+            "dtend_utc": "2030-01-01T09:30:00Z",
+        },
+        fingerprint="",
+    )
+
+
+def test_create_item_error_message_includes_properties_list():
+    adapter = _adapter_with_create_failure(["recurrenceRules"])
+    with pytest.raises(ValueError) as exc_info:
+        adapter.create_item("cal-1", _item())
+    assert "properties: ['recurrenceRules']" in str(exc_info.value)
+
+
+def test_create_item_error_message_without_properties():
+    adapter = _adapter_with_create_failure(None)
+    with pytest.raises(ValueError) as exc_info:
+        adapter.create_item("cal-1", _item())
+    msg = str(exc_info.value)
+    assert "invalidProperties" in msg
+    assert "properties" not in msg  # no "(properties: [...])" segment


### PR DESCRIPTION
## Summary

JMAP \`CalendarEvent/set\` errors carry a \`properties\` array that names the offending field(s). Stalwart uses this on \`invalidProperties\` to pinpoint what it rejected. \`create_item\` was only capturing \`type\` and \`description\`, so operators saw:

\`\`\`
invalidProperties — Invalid property.
\`\`\`

…with no hint of which field was the problem. This PR widens the error message to include the \`properties\` list when the server provides one:

\`\`\`
invalidProperties — Invalid property. (properties: ['recurrenceRules'])
\`\`\`

## Why

Hours of probing were needed to discover that Stalwart rejects every shape of \`recurrenceRules\` on \`CalendarEvent/set\`. The server was telling us the answer in the error response all along — we were just throwing the \`properties\` array on the floor. Shipping this so the next unknown gets diagnosed in seconds, not sessions.

## Scope

- Extract a \`_format_set_error(prefix, err)\` helper alongside \`_redact_event_payload\`.
- Use it in \`create_item\`'s \`notCreated\` branch. (\`update_item\` already logged the full \`not_updated[...]\` dict to \`log.error\`, so the \`properties\` list was already visible there.)
- No behaviour change beyond the message text.

## Test plan

- [x] \`pytest tests/test_jmap_set_error_formatting.py -v\` — 5 helper unit tests + 2 integration tests covering the create_item path with and without \`properties\`.
- [x] \`pytest -m "not e2e" -q\` — 200 passed, no regressions.
- [x] \`ruff check\` — clean.