### PR TITLE
fix(graph-calendar): log Graph 4xx response body on create/update

### DIFF
--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -8,6 +8,8 @@ recurrence↔RRULE translation.
 """
 from __future__ import annotations
 
+import copy
+import json
 import logging
 import time
 from datetime import datetime
@@ -98,6 +100,72 @@ _PARTSTAT_TO_RESPONSE: dict[str, str] = {
     "declined": "declined",
     "tentative": "tentativelyAccepted",
 }
+
+
+def _redact_graph_payload(body: dict[str, Any]) -> dict[str, Any]:
+    """Return a deep copy of *body* with free-text fields redacted.
+
+    Same intent as the JMAP adapter's _redact_event_payload: on a Graph
+    4xx the server's error message almost always names a structural
+    property (capacity limits, invalid enum, etc.); free-text fields
+    only leak meeting content into operator logs without helping the
+    diagnosis. Redact those.
+
+    Redacted keys (when present, regardless of nesting depth):
+      * top-level ``subject``
+      * ``body.content``
+      * ``location.displayName`` (singular) and any ``locations[*].displayName``
+      * ``attendees[*].emailAddress.{address,name}``
+      * ``organizer.emailAddress.{address,name}``
+    """
+    out = copy.deepcopy(body)
+    if "subject" in out:
+        out["subject"] = "<redacted>"
+    body_field = out.get("body")
+    if isinstance(body_field, dict) and "content" in body_field:
+        body_field["content"] = "<redacted>"
+    loc = out.get("location")
+    if isinstance(loc, dict) and "displayName" in loc:
+        loc["displayName"] = "<redacted>"
+    locs = out.get("locations")
+    if isinstance(locs, list):
+        for entry in locs:
+            if isinstance(entry, dict) and "displayName" in entry:
+                entry["displayName"] = "<redacted>"
+    attendees = out.get("attendees")
+    if isinstance(attendees, list):
+        for att in attendees:
+            ea = att.get("emailAddress") if isinstance(att, dict) else None
+            if isinstance(ea, dict):
+                if "address" in ea:
+                    ea["address"] = "<redacted>"
+                if "name" in ea:
+                    ea["name"] = "<redacted>"
+    org = out.get("organizer")
+    if isinstance(org, dict):
+        ea = org.get("emailAddress")
+        if isinstance(ea, dict):
+            if "address" in ea:
+                ea["address"] = "<redacted>"
+            if "name" in ea:
+                ea["name"] = "<redacted>"
+    return out
+
+
+def _format_graph_error(prefix: str, response: httpx.Response) -> str:
+    """Extract Graph's error code + message from a 4xx response body and
+    format a human-readable exception message. Falls back gracefully
+    when the body isn't JSON or doesn't carry the expected shape."""
+    try:
+        payload = response.json()
+    except (ValueError, json.JSONDecodeError):
+        return f"{prefix}: HTTP {response.status_code} (non-JSON body)"
+    err = payload.get("error") if isinstance(payload, dict) else None
+    if not isinstance(err, dict):
+        return f"{prefix}: HTTP {response.status_code} {payload!r}"
+    code = err.get("code", "unknown")
+    message = err.get("message", "")
+    return f"{prefix}: HTTP {response.status_code} {code} — {message}"
 
 
 def _tree_identity_key(event: dict[str, Any]) -> Optional[str]:
@@ -438,6 +506,15 @@ class GraphCalendarAdapter(SyncProvider):
         r = self._write_request(
             "POST", f"/me/calendars/{container_id}/events", json=body
         )
+        if 400 <= r.status_code < 500:
+            if log.isEnabledFor(logging.DEBUG):
+                log.debug(
+                    "Graph create failed — request payload: %s",
+                    json.dumps(_redact_graph_payload(body), default=repr),
+                )
+            raise ValueError(_format_graph_error(
+                "Graph create event failed", r,
+            ))
         r.raise_for_status()
         data = r.json()
         return data["id"], data.get("lastModifiedDateTime", "")
@@ -446,6 +523,16 @@ class GraphCalendarAdapter(SyncProvider):
         """Update an existing event. Returns server-assigned fingerprint."""
         body = _sync_item_to_graph(item)
         r = self._write_request("PATCH", f"/me/events/{item.provider_id}", json=body)
+        if 400 <= r.status_code < 500:
+            if log.isEnabledFor(logging.DEBUG):
+                log.debug(
+                    "Graph update %s failed — request payload: %s",
+                    item.provider_id,
+                    json.dumps(_redact_graph_payload(body), default=repr),
+                )
+            raise ValueError(_format_graph_error(
+                f"Graph update event {item.provider_id} failed", r,
+            ))
         r.raise_for_status()
         return r.json().get("lastModifiedDateTime", "")
 

--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -111,7 +111,9 @@ def _redact_graph_payload(body: dict[str, Any]) -> dict[str, Any]:
     only leak meeting content into operator logs without helping the
     diagnosis. Redact those.
 
-    Redacted keys (when present, regardless of nesting depth):
+    Redacted at the documented Graph event paths only — no recursive
+    descent. The Graph event schema is fixed, so explicit paths cover
+    every place free text appears in our writes:
       * top-level ``subject``
       * ``body.content``
       * ``location.displayName`` (singular) and any ``locations[*].displayName``
@@ -158,7 +160,9 @@ def _format_graph_error(prefix: str, response: httpx.Response) -> str:
     when the body isn't JSON or doesn't carry the expected shape."""
     try:
         payload = response.json()
-    except (ValueError, json.JSONDecodeError):
+    except ValueError:
+        # json.JSONDecodeError is a ValueError subclass; one except
+        # covers both invalid-JSON and unexpected-shape parse paths.
         return f"{prefix}: HTTP {response.status_code} (non-JSON body)"
     err = payload.get("error") if isinstance(payload, dict) else None
     if not isinstance(err, dict):

--- a/tests/test_graph_write_error_logging.py
+++ b/tests/test_graph_write_error_logging.py
@@ -1,0 +1,155 @@
+"""On a Graph 4xx during create or update, the adapter must:
+  * extract Graph's error.code + error.message into the ValueError
+  * log the redacted request payload at DEBUG so the offending
+    property is visible without exposing free-text content
+
+Mirrors the diagnostic logging the JMAP adapter already has."""
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from groupware_sync.models import ItemType, SyncItem
+from groupware_sync_calendar.adapters.graph_adapter import (
+    GRAPH_BASE,
+    GraphCalendarAdapter,
+    _format_graph_error,
+    _redact_graph_payload,
+)
+
+# -- Redaction helper --------------------------------------------------------
+
+
+def test_redact_graph_payload_is_pure():
+    body = {
+        "subject": "Lunch with Alice",
+        "body": {"contentType": "text", "content": "private notes"},
+        "location": {"displayName": "Bistro Rue"},
+        "locations": [{"displayName": "Café"}],
+        "attendees": [
+            {"emailAddress": {"address": "a@x", "name": "A"}, "type": "required"},
+        ],
+        "organizer": {"emailAddress": {"address": "me@x", "name": "Me"}},
+        "start": {"dateTime": "2030-01-01T09:00:00", "timeZone": "UTC"},
+    }
+    out = _redact_graph_payload(body)
+    assert out["subject"] == "<redacted>"
+    assert out["body"]["content"] == "<redacted>"
+    assert out["location"]["displayName"] == "<redacted>"
+    assert out["locations"][0]["displayName"] == "<redacted>"
+    assert out["attendees"][0]["emailAddress"]["address"] == "<redacted>"
+    assert out["attendees"][0]["emailAddress"]["name"] == "<redacted>"
+    assert out["organizer"]["emailAddress"]["address"] == "<redacted>"
+    # Structural fields preserved.
+    assert out["start"] == body["start"]
+    assert out["body"]["contentType"] == "text"
+    assert out["attendees"][0]["type"] == "required"
+    # Input not mutated.
+    assert body["subject"] == "Lunch with Alice"
+
+
+def test_redact_graph_payload_handles_missing_fields():
+    out = _redact_graph_payload({"start": {"dateTime": "x", "timeZone": "UTC"}})
+    assert out == {"start": {"dateTime": "x", "timeZone": "UTC"}}
+
+
+# -- Graph error formatter ---------------------------------------------------
+
+
+def _resp(status: int, body: dict | str) -> httpx.Response:
+    if isinstance(body, dict):
+        return httpx.Response(status, json=body, request=httpx.Request("POST", "https://x"))
+    return httpx.Response(status, text=body, request=httpx.Request("POST", "https://x"))
+
+
+def test_format_graph_error_with_typed_error_body():
+    r = _resp(400, {"error": {"code": "ErrorInvalidPropertyRequest", "message": "Foo bar."}})
+    assert _format_graph_error("X", r) == "X: HTTP 400 ErrorInvalidPropertyRequest — Foo bar."
+
+
+def test_format_graph_error_without_error_object():
+    r = _resp(400, {"value": []})
+    assert "HTTP 400" in _format_graph_error("X", r)
+
+
+def test_format_graph_error_non_json_body():
+    r = _resp(400, "Bad request, not JSON")
+    assert _format_graph_error("X", r) == "X: HTTP 400 (non-JSON body)"
+
+
+# -- Adapter integration: create + update raise rich ValueError --------------
+
+
+def _adapter_with_response(resp: httpx.Response) -> GraphCalendarAdapter:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return resp
+    a = GraphCalendarAdapter("token")
+    a._client = httpx.Client(
+        base_url=GRAPH_BASE,
+        headers={"Authorization": "Bearer token"},
+        transport=httpx.MockTransport(handler),
+        timeout=5.0,
+    )
+    return a
+
+
+def _item() -> SyncItem:
+    return SyncItem(
+        provider_id="graph-id-x",
+        item_type=ItemType.CALENDAR_EVENT,
+        fields={
+            "uid": "ev-1",
+            "summary": "Lunch with Alice",
+            "description": "Private notes",
+            "dtstart_utc": "2030-01-01T09:00:00Z",
+            "dtstart_tz": "Europe/Stockholm",
+            "dtend_utc": "2030-01-01T09:30:00Z",
+            "dtend_tz": "Europe/Stockholm",
+        },
+        fingerprint="",
+    )
+
+
+def test_create_item_raises_value_error_on_400():
+    err_body = {
+        "error": {"code": "ErrorInvalidPropertyRequest", "message": "Bad attendees."},
+    }
+    adapter = _adapter_with_response(_resp(400, err_body))
+    with pytest.raises(ValueError) as exc_info:
+        adapter.create_item("cal-1", _item())
+    msg = str(exc_info.value)
+    assert "HTTP 400" in msg
+    assert "ErrorInvalidPropertyRequest" in msg
+    assert "Bad attendees." in msg
+
+
+def test_update_item_raises_value_error_on_400():
+    err_body = {
+        "error": {"code": "ErrorRequestBodyTooLarge", "message": "Too big."},
+    }
+    adapter = _adapter_with_response(_resp(400, err_body))
+    with pytest.raises(ValueError) as exc_info:
+        adapter.update_item("cal-1", _item())
+    msg = str(exc_info.value)
+    assert "graph-id-x" in msg
+    assert "ErrorRequestBodyTooLarge" in msg
+    assert "Too big." in msg
+
+
+def test_create_item_emits_debug_log_with_redacted_payload(caplog):
+    err_body = {"error": {"code": "Bad", "message": "Bad."}}
+    adapter = _adapter_with_response(_resp(400, err_body))
+    caplog.set_level(logging.DEBUG, logger="groupware_sync_calendar.adapters.graph_adapter")
+    with pytest.raises(ValueError):
+        adapter.create_item("cal-1", _item())
+    debug = [r for r in caplog.records
+             if r.levelno == logging.DEBUG and "request payload" in r.getMessage()]
+    assert len(debug) == 1
+    msg = debug[0].getMessage()
+    assert "Lunch with Alice" not in msg
+    assert "Private notes" not in msg
+    assert "<redacted>" in msg
+    # Structural keys still present so the operator can diagnose.
+    assert "start" in msg or "timeZone" in msg

--- a/tests/test_graph_write_error_logging.py
+++ b/tests/test_graph_write_error_logging.py
@@ -153,3 +153,19 @@ def test_create_item_emits_debug_log_with_redacted_payload(caplog):
     assert "<redacted>" in msg
     # Structural keys still present so the operator can diagnose.
     assert "start" in msg or "timeZone" in msg
+
+
+def test_update_item_emits_debug_log_with_redacted_payload(caplog):
+    err_body = {"error": {"code": "Bad", "message": "Bad."}}
+    adapter = _adapter_with_response(_resp(400, err_body))
+    caplog.set_level(logging.DEBUG, logger="groupware_sync_calendar.adapters.graph_adapter")
+    with pytest.raises(ValueError):
+        adapter.update_item("cal-1", _item())
+    debug = [r for r in caplog.records
+             if r.levelno == logging.DEBUG and "request payload" in r.getMessage()]
+    assert len(debug) == 1
+    msg = debug[0].getMessage()
+    assert "Lunch with Alice" not in msg
+    assert "Private notes" not in msg
+    assert "<redacted>" in msg
+    assert "start" in msg or "timeZone" in msg


### PR DESCRIPTION
## Summary

The Graph adapter was calling \`raise_for_status()\` on \`create_item\`/\`update_item\` and discarding the response body. Graph's error responses carry a structured \`error.code + error.message\` that names the rejected property — operators saw only \`400 Bad Request\` with no idea what Graph actually rejected. Same diagnostic gap PR #7/#13 closed for the JMAP side; mirror it on Graph.

## Why now

Live sync is producing \`Failed to update <id> on m365\` errors with a bare \`HTTPStatusError: 400 Bad Request\` and zero context. We've spent multiple sessions reverse-engineering "which property" via probes that should have been one log line. Closing the gap before the next puzzle.

## Scope

- \`_redact_graph_payload\` — deep copy + redact \`subject\`, \`body.content\`, \`location/locations[*].displayName\`, \`attendees[*].emailAddress.{address,name}\`, \`organizer.emailAddress.{address,name}\`. Structural keys preserved.
- \`_format_graph_error\` — pull \`error.code + error.message\` from a JSON body, fall back gracefully on non-JSON.
- \`create_item\` / \`update_item\` — on 4xx, emit DEBUG log with redacted payload (gated by \`--verbose\`), then raise \`ValueError\` with formatted error. 2xx/5xx behaviour unchanged.

## Test plan

- [x] \`pytest tests/test_graph_write_error_logging.py -v\` — 8 tests covering redaction (purity, structural preservation, missing-field tolerance), error formatting (typed/untyped/non-JSON), and adapter integration in both create and update.
- [x] \`pytest -m "not e2e" -q\` — 201 passed, no regressions.
- [x] \`ruff check\` — clean.
- [ ] On merge: re-run live sync, see Graph's actual error code+message in the \`ValueError\` exception. The current \`errors=2\` from PATCH 400s should reveal which property Graph rejects.