### PR TITLE
ci: ignore CVE-2026-3219 (pip) in vuln-scan until upstream fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
-      - run: uv run --extra dev pip-audit
+      # CVE-2026-3219 affects `pip` itself, which uv's audit environment
+      # bundles transitively. No fixed version is published yet
+      # (pip-audit shows the Fix Versions column empty), and pip is not
+      # used at runtime by this project. Re-enable scanning of pip once
+      # an upstream fix lands; revisit this ignore on each CVE refresh.
+      - run: uv run --extra dev pip-audit --ignore-vuln CVE-2026-3219


### PR DESCRIPTION
## Summary

\`pip 26.0.1\` is flagged by \`pip-audit\` with **CVE-2026-3219** and no fix version published yet (the \`Fix Versions\` column from pip-audit is empty). Adding \`--ignore-vuln CVE-2026-3219\` to the vuln-scan job's pip-audit invocation so unrelated PRs stop being blocked.

## Why this is safe

- pip is a transitive dependency of uv's audit environment, not a runtime dependency of this project. Nothing we ship uses pip.
- The lint, test, and e2e CI jobs are independent of vuln-scan and continue to enforce code-quality gates.
- The ignore is scoped to one CVE id with a comment referencing it, so the next CVE-refresh review will surface it for re-evaluation.

## What unblocks

PR #15 (Graph 4xx error logging) was failing only on this scan; once this lands and merges, #15's vuln-scan will pass too.

## Test plan

- [x] CI run on this branch will exercise the new \`--ignore-vuln\` flag and confirm vuln-scan now passes.