### PR TITLE
fix(graph-calendar): include range.startDate on recurrence emit

### DIFF
--- a/src/groupware_sync_calendar/adapters/graph_adapter.py
+++ b/src/groupware_sync_calendar/adapters/graph_adapter.py
@@ -784,7 +784,16 @@ def _sync_item_to_graph(item: SyncItem) -> dict[str, Any]:
     # Recurrence
     if fields.get("rrule") is not None:
         try:
-            body["recurrence"] = rrule_to_graph_recurrence(fields["rrule"])
+            # Graph requires range.startDate on every recurrence object;
+            # without it, PATCH fails with `ErrorInvalidOperation: The
+            # recurrence start date is too early.` (CREATE accepts a
+            # missing startDate but Graph rejects on update). Pass the
+            # YYYY-MM-DD prefix of the event's dtstart_utc.
+            dtstart_utc = fields.get("dtstart_utc") or ""
+            start_date = dtstart_utc[:10] if len(dtstart_utc) >= 10 else None
+            body["recurrence"] = rrule_to_graph_recurrence(
+                fields["rrule"], start_date=start_date,
+            )
         except (ValueError, KeyError) as e:
             log.warning("failed to convert rrule to graph recurrence: %s", e)
 

--- a/src/groupware_sync_calendar/rrule.py
+++ b/src/groupware_sync_calendar/rrule.py
@@ -107,11 +107,21 @@ def graph_recurrence_to_rrule(recurrence: dict[str, Any]) -> str:
     return ";".join(parts)
 
 
-def rrule_to_graph_recurrence(rrule: str) -> dict[str, Any]:
+def rrule_to_graph_recurrence(
+    rrule: str, start_date: str | None = None
+) -> dict[str, Any]:
     """Convert an RFC 5545 RRULE string to a Microsoft Graph recurrence object.
 
     Args:
         rrule: RRULE string, e.g. ``FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,WE,FR``.
+        start_date: Anchor date for ``range.startDate`` in YYYY-MM-DD form.
+            Microsoft Graph requires ``range.startDate`` on every recurrence
+            object — it's optional in the JSON shape but the API rejects
+            PATCH requests without it (returning ``ErrorInvalidOperation:
+            The recurrence start date is too early`` because Graph falls
+            back to an epoch-class sentinel). Callers MUST pass the
+            event's start date (the YYYY-MM-DD prefix of dtstart_utc) so
+            the resulting object survives both POST and PATCH.
 
     Returns:
         Graph recurrence dict with ``pattern`` and ``range`` keys.
@@ -173,6 +183,8 @@ def rrule_to_graph_recurrence(rrule: str) -> dict[str, Any]:
         rng["numberOfOccurrences"] = int(params["COUNT"])
     else:
         rng["type"] = "noEnd"
+    if start_date:
+        rng["startDate"] = start_date
 
     return {"pattern": pattern, "range": rng}
 

--- a/tests/test_calendar_rrule.py
+++ b/tests/test_calendar_rrule.py
@@ -135,6 +135,33 @@ def test_rrule_to_graph_with_until():
     assert result["range"]["endDate"] == "2026-12-31"
 
 
+def test_rrule_to_graph_includes_start_date_when_provided():
+    """range.startDate is required by Graph on PATCH; the helper must
+    populate it when callers pass start_date."""
+    result = rrule_to_graph_recurrence(
+        "FREQ=WEEKLY;BYDAY=MO", start_date="2026-04-16",
+    )
+    assert result["range"]["startDate"] == "2026-04-16"
+
+
+def test_rrule_to_graph_omits_start_date_when_not_provided():
+    """Backwards compatible: callers that don't pass start_date still
+    get a working object (modulo Graph's PATCH requirement). Avoid
+    fabricating a sentinel; just leave the field absent."""
+    result = rrule_to_graph_recurrence("FREQ=WEEKLY;BYDAY=MO")
+    assert "startDate" not in result["range"]
+
+
+def test_rrule_to_graph_start_date_combines_with_until():
+    result = rrule_to_graph_recurrence(
+        "FREQ=DAILY;INTERVAL=1;UNTIL=20261231",
+        start_date="2026-04-16",
+    )
+    assert result["range"]["type"] == "endDate"
+    assert result["range"]["endDate"] == "2026-12-31"
+    assert result["range"]["startDate"] == "2026-04-16"
+
+
 def test_roundtrip_weekly():
     original = "FREQ=WEEKLY;INTERVAL=2;BYDAY=TU,TH;COUNT=20"
     graph = rrule_to_graph_recurrence(original)

--- a/tests/test_graph_recurrence_startdate.py
+++ b/tests/test_graph_recurrence_startdate.py
@@ -1,0 +1,81 @@
+"""Microsoft Graph requires `range.startDate` on every recurrence
+object. CREATE accepted a missing startDate (Graph defaulted to the
+event's start), but PATCH on an existing event rejected with
+``ErrorInvalidOperation: The recurrence start date is too early.``
+
+The Graph adapter's _sync_item_to_graph must derive startDate from
+the event's dtstart_utc when emitting recurrence."""
+from __future__ import annotations
+
+from groupware_sync.models import ItemType, SyncItem
+from groupware_sync_calendar.adapters.graph_adapter import _sync_item_to_graph
+
+
+def _item(rrule: str | None, dtstart_utc: str = "2026-04-16T14:00:00Z") -> SyncItem:
+    fields: dict = {
+        "uid": "ev-1",
+        "summary": "weekly standup",
+        "dtstart_utc": dtstart_utc,
+        "dtstart_tz": "Etc/UTC",
+        "dtend_utc": "2026-04-16T14:30:00Z",
+        "dtend_tz": "Etc/UTC",
+    }
+    if rrule:
+        fields["rrule"] = rrule
+    return SyncItem(
+        provider_id="graph-id",
+        item_type=ItemType.CALENDAR_EVENT,
+        fields=fields,
+        fingerprint="",
+    )
+
+
+def test_recurrence_includes_startDate_from_dtstart_utc():
+    body = _sync_item_to_graph(_item("FREQ=WEEKLY;BYDAY=MO"))
+    assert "recurrence" in body
+    rng = body["recurrence"]["range"]
+    assert rng.get("startDate") == "2026-04-16"
+
+
+def test_recurrence_startDate_is_date_only_yyyy_mm_dd():
+    """Graph wants a date string, not a datetime."""
+    body = _sync_item_to_graph(
+        _item("FREQ=DAILY", dtstart_utc="2030-12-31T23:59:00Z"),
+    )
+    assert body["recurrence"]["range"]["startDate"] == "2030-12-31"
+
+
+def test_recurrence_with_until_keeps_both_dates():
+    body = _sync_item_to_graph(
+        _item("FREQ=WEEKLY;BYDAY=MO;UNTIL=20261231",
+              dtstart_utc="2026-04-16T14:00:00Z"),
+    )
+    rng = body["recurrence"]["range"]
+    assert rng["type"] == "endDate"
+    assert rng["startDate"] == "2026-04-16"
+    assert rng["endDate"] == "2026-12-31"
+
+
+def test_no_recurrence_means_no_recurrence_field():
+    body = _sync_item_to_graph(_item(None))
+    assert "recurrence" not in body
+
+
+def test_recurrence_without_dtstart_utc_omits_startDate():
+    """Defensive: if dtstart_utc somehow isn't populated, the recurrence
+    still emits without crashing — startDate just isn't set. Graph's
+    PATCH would reject in that scenario, but the adapter shouldn't
+    raise when emitting."""
+    item = SyncItem(
+        provider_id="graph-id",
+        item_type=ItemType.CALENDAR_EVENT,
+        fields={
+            "uid": "ev-1",
+            "summary": "X",
+            "rrule": "FREQ=WEEKLY",
+        },
+        fingerprint="",
+    )
+    body = _sync_item_to_graph(item)
+    assert "recurrence" in body
+    assert "startDate" not in body["recurrence"]["range"]


### PR DESCRIPTION
## Summary

PR #15's Graph 4xx logging unmasked the last error blocking steady state:

\`\`\`
HTTP 400 ErrorInvalidOperation — The recurrence start date is too early.
\`\`\`

\`rrule_to_graph_recurrence\` was building \`{pattern, range}\` without setting \`range.startDate\`. Graph's CREATE silently filled in \`startDate\` from the event's \`start.dateTime\`, so the bug stayed hidden until a recurring event first hit the engine's first-sync-merge PATCH path. PATCH apparently doesn't apply that default, so Graph fell back to an epoch-class sentinel and rejected its own request.

## Fix

- \`rrule_to_graph_recurrence(rrule, start_date=None)\` — accepts a \`start_date\` keyword. When present, emits \`range.startDate\`.
- \`_sync_item_to_graph\` — derives \`start_date\` from the YYYY-MM-DD prefix of \`fields["dtstart_utc"]\` and passes it through. Defensive: missing \`dtstart_utc\` still emits a recurrence (without \`startDate\`) rather than raising.

## Test plan

- [x] \`pytest tests/test_calendar_rrule.py tests/test_graph_recurrence_startdate.py -v\` — 22 pass. Eight new cases covering helper backward-compat, helper with start_date, helper combined with UNTIL, adapter integration including date-only output and the no-rrule path.
- [x] \`pytest -m "not e2e" -q\` — 224 passed, no regressions.
- [x] \`ruff check\` — clean.
- [ ] On merge: re-run live sync. Expected: \`errors=0\`. The last \`ErrorInvalidOperation\` should disappear; the next dry-run after that should plan near-zero ops — true steady state.

## How we got here efficiently

PR #13 surfaced JMAP's \`properties\` array; PR #15 mirrored Graph's \`error.code + error.message\`. Both turned multi-session probe sessions into single-line diagnoses. This PR is the first one in the saga that didn't need a probe — the error said exactly what was wrong.