### PR TITLE
fix(tree): resolve unpairable leaves via cached provider-id mapping

### DIFF
--- a/src/groupware_sync/engine.py
+++ b/src/groupware_sync/engine.py
@@ -546,7 +546,7 @@ def _merge_one(
         snapshot = ops.load_snapshot_item(snap_row)
 
     # Three-way merge
-    merged, changed_vs_a, changed_vs_b, conflict_count = merge_item(
+    merged, changed_vs_a, changed_vs_b, conflict_count, drift = merge_item(
         item_a, item_b, snapshot, type_spec
     )
     summary.conflicts += conflict_count
@@ -559,7 +559,10 @@ def _merge_one(
         merged_for_a = dataclasses.replace(merged, provider_id=a_id)
         try:
             new_fp_a = provider_a.update_item(cid_a, merged_for_a)
-            log.debug("Updated item %s on %s (fp=%s)", a_id, provider_a.name, new_fp_a)
+            log.info(
+                "Updated %s on %s — drift fields: %s",
+                a_id, provider_a.name, ", ".join(drift["a"]) or "(none)",
+            )
         except Exception:
             log.exception("Failed to update %s on %s", a_id, provider_a.name)
             summary.errors += 1
@@ -568,7 +571,10 @@ def _merge_one(
         merged_for_b = dataclasses.replace(merged, provider_id=b_id)
         try:
             new_fp_b = provider_b.update_item(cid_b, merged_for_b)
-            log.debug("Updated item %s on %s (fp=%s)", b_id, provider_b.name, new_fp_b)
+            log.info(
+                "Updated %s on %s — drift fields: %s",
+                b_id, provider_b.name, ", ".join(drift["b"]) or "(none)",
+            )
         except Exception:
             log.exception("Failed to update %s on %s", b_id, provider_b.name)
             summary.errors += 1
@@ -693,7 +699,7 @@ def _execute_creates(
         op_b = b_items[b_id][1]
 
         # Three-way merge with no snapshot (first sync)
-        merged, changed_vs_a, changed_vs_b, conflict_count = merge_item(
+        merged, changed_vs_a, changed_vs_b, conflict_count, drift = merge_item(
             item_a, item_b, None, type_spec
         )
         summary.conflicts += conflict_count
@@ -706,6 +712,10 @@ def _execute_creates(
             merged_for_a = dataclasses.replace(merged, provider_id=a_id)
             try:
                 new_fp_a = provider_a.update_item(op_a.container_id_a, merged_for_a)
+                log.info(
+                    "First-sync update %s on %s — drift fields: %s",
+                    a_id, provider_a.name, ", ".join(drift["a"]) or "(none)",
+                )
             except Exception:
                 log.exception("Failed to update matched %s on %s", a_id, provider_a.name)
                 summary.errors += 1
@@ -714,6 +724,10 @@ def _execute_creates(
             merged_for_b = dataclasses.replace(merged, provider_id=b_id)
             try:
                 new_fp_b = provider_b.update_item(op_b.container_id_b, merged_for_b)
+                log.info(
+                    "First-sync update %s on %s — drift fields: %s",
+                    b_id, provider_b.name, ", ".join(drift["b"]) or "(none)",
+                )
             except Exception:
                 log.exception("Failed to update matched %s on %s", b_id, provider_b.name)
                 summary.errors += 1

--- a/src/groupware_sync/merge.py
+++ b/src/groupware_sync/merge.py
@@ -92,7 +92,7 @@ def merge_item(
     item_b: SyncItem,
     snapshot: Optional[SyncItem],
     type_spec: TypeSpec,
-) -> tuple[SyncItem, bool, bool, int]:
+) -> tuple[SyncItem, bool, bool, int, dict[str, list[str]]]:
     """Merge two versions of an item using field-level strategies.
 
     Args:
@@ -102,15 +102,17 @@ def merge_item(
         type_spec: Field definitions with merge strategies.
 
     Returns:
-        (merged_item, changed_vs_a, changed_vs_b, conflict_count)
+        (merged_item, changed_vs_a, changed_vs_b, conflict_count, drift)
         - changed_vs_a: True if merged result differs from item_a
         - changed_vs_b: True if merged result differs from item_b
         - conflict_count: number of fields that required last-write-wins arbitration
+        - drift: {"a": [field names that diverge from item_a],
+                  "b": [field names that diverge from item_b]}
     """
     merged_fields: dict[str, Any] = {}
     conflict_count = 0
-    changed_vs_a = False
-    changed_vs_b = False
+    drift_a: list[str] = []
+    drift_b: list[str] = []
 
     no_snapshot = snapshot is None
 
@@ -129,9 +131,9 @@ def merge_item(
             merged_val = val_a if val_a is not None else val_b
             merged_fields[fname] = merged_val
             if merged_val != val_a:
-                changed_vs_a = True
+                drift_a.append(fname)
             if merged_val != val_b:
-                changed_vs_b = True
+                drift_b.append(fname)
             continue
 
         if strategy == MergeStrategy.SET:
@@ -147,9 +149,9 @@ def merge_item(
             )
             merged_fields[fname] = result
             if chg_vs_a:
-                changed_vs_a = True
+                drift_a.append(fname)
             if chg_vs_b:
-                changed_vs_b = True
+                drift_b.append(fname)
             continue
 
         # SCALAR strategy
@@ -175,9 +177,9 @@ def merge_item(
 
         merged_fields[fname] = merged_val
         if merged_val != val_a:
-            changed_vs_a = True
+            drift_a.append(fname)
         if merged_val != val_b:
-            changed_vs_b = True
+            drift_b.append(fname)
 
     merged_updated_at = _max_timestamp(item_a.updated_at, item_b.updated_at)
     merged = SyncItem(
@@ -187,4 +189,10 @@ def merge_item(
         updated_at=merged_updated_at,
     )
 
-    return merged, changed_vs_a, changed_vs_b, conflict_count
+    return (
+        merged,
+        bool(drift_a),
+        bool(drift_b),
+        conflict_count,
+        {"a": drift_a, "b": drift_b},
+    )

--- a/src/groupware_sync/merge.py
+++ b/src/groupware_sync/merge.py
@@ -109,6 +109,8 @@ def merge_item(
     """
     merged_fields: dict[str, Any] = {}
     conflict_count = 0
+    changed_vs_a = False
+    changed_vs_b = False
 
     no_snapshot = snapshot is None
 
@@ -124,20 +126,30 @@ def merge_item(
         val_prev = snapshot.fields.get(fname) if snapshot is not None else None
 
         if strategy == MergeStrategy.IMMUTABLE:
-            merged_fields[fname] = val_a if val_a is not None else val_b
+            merged_val = val_a if val_a is not None else val_b
+            merged_fields[fname] = merged_val
+            if merged_val != val_a:
+                changed_vs_a = True
+            if merged_val != val_b:
+                changed_vs_b = True
             continue
 
         if strategy == MergeStrategy.SET:
             if no_snapshot:
-                # Treat as both changed: union everything
                 a_changed = True
                 b_changed = True
             else:
                 a_changed = val_a != val_prev
                 b_changed = val_b != val_prev
 
-            result, _chg_vs_a, _chg_vs_b = _merge_set(val_a, val_b, val_prev, a_changed, b_changed)
+            result, chg_vs_a, chg_vs_b = _merge_set(
+                val_a, val_b, val_prev, a_changed, b_changed,
+            )
             merged_fields[fname] = result
+            if chg_vs_a:
+                changed_vs_a = True
+            if chg_vs_b:
+                changed_vs_b = True
             continue
 
         # SCALAR strategy
@@ -149,24 +161,23 @@ def merge_item(
             b_changed = val_b != val_prev
 
         if not a_changed and not b_changed:
-            # Neither changed: keep snapshot value (same as both)
-            merged_fields[fname] = val_prev
+            merged_val = val_prev
         elif a_changed and not b_changed:
-            # Only A changed: take A
-            merged_fields[fname] = val_a
+            merged_val = val_a
         elif b_changed and not a_changed:
-            # Only B changed: take B
-            merged_fields[fname] = val_b
+            merged_val = val_b
+        elif val_a == val_b:
+            merged_val = val_a
         else:
-            # Both changed
-            if val_a == val_b:
-                # Same value: no conflict
-                merged_fields[fname] = val_a
-            else:
-                # True conflict: last-write-wins
-                conflict_count += 1
-                winner = _pick_winner(item_a, item_b)
-                merged_fields[fname] = val_a if winner == "a" else val_b
+            conflict_count += 1
+            winner = _pick_winner(item_a, item_b)
+            merged_val = val_a if winner == "a" else val_b
+
+        merged_fields[fname] = merged_val
+        if merged_val != val_a:
+            changed_vs_a = True
+        if merged_val != val_b:
+            changed_vs_b = True
 
     merged_updated_at = _max_timestamp(item_a.updated_at, item_b.updated_at)
     merged = SyncItem(
@@ -175,15 +186,5 @@ def merge_item(
         fields=merged_fields,
         updated_at=merged_updated_at,
     )
-
-    # Final check: compare merged fields to each side's full fields
-    # (only for fields we actually processed)
-    processed_names = {f.name for f in type_spec.fields if f.merge_strategy != MergeStrategy.IGNORE}
-    merged_subset_a = {k: item_a.fields.get(k) for k in processed_names}
-    merged_subset_b = {k: item_b.fields.get(k) for k in processed_names}
-    merged_subset = {k: merged_fields.get(k) for k in processed_names if k in merged_fields}
-
-    changed_vs_a = merged_subset != merged_subset_a
-    changed_vs_b = merged_subset != merged_subset_b
 
     return merged, changed_vs_a, changed_vs_b, conflict_count

--- a/src/groupware_sync/tree.py
+++ b/src/groupware_sync/tree.py
@@ -247,12 +247,12 @@ def _compare_node(
         if leaf_a_alt is None or leaf_b_alt is None:
             continue
         fp_changed_a = (
-            mapping.fingerprint_a is not None
-            and leaf_a_alt.fingerprint != mapping.fingerprint_a
+            mapping.fingerprint_a is None
+            or leaf_a_alt.fingerprint != mapping.fingerprint_a
         )
         fp_changed_b = (
-            mapping.fingerprint_b is not None
-            and leaf_b_alt.fingerprint != mapping.fingerprint_b
+            mapping.fingerprint_b is None
+            or leaf_b_alt.fingerprint != mapping.fingerprint_b
         )
         if fp_changed_a or fp_changed_b:
             leaf_ops.append(

--- a/src/groupware_sync/tree.py
+++ b/src/groupware_sync/tree.py
@@ -214,19 +214,88 @@ def _compare_node(
     cached = ops.get_mappings_by_identity(session, pair.id)
     had_cache = bool(cached)
 
+    # Resolve cached mappings against the unpairable buckets via
+    # provider_id BEFORE the main loop. When two leaves share an
+    # identity_key (collision), `_bucket` demotes both to unpairable
+    # to avoid silently picking the wrong pair. Subsequent runs would
+    # then plan CREATE_ITEMs for them, `_execute_creates` would
+    # re-pair via _identity_match and store an ItemMapping under
+    # `_legacy_identity_key(a_id, b_id)`, and the next run wouldn't
+    # find that legacy key — so it would clean it up as `(both gone)`
+    # and re-create the pair forever. The cycle is observable as a
+    # dry-run that always plans the same N creates and N deletes
+    # despite the data being stable.
+    #
+    # Break the cycle by trusting cached pairs over identity-based
+    # pairing here: if the mapping's `a_item_id` and `b_item_id` both
+    # appear in the unpairable buckets, treat them as paired. Emit
+    # MERGE_ITEM only when fingerprints drifted, otherwise emit
+    # nothing at all and remove both leaves from the unpairable
+    # buckets so they don't get re-CREATEd below.
+    unpairable_a_by_id: dict[str, SyncNode] = {
+        leaf.node_id: leaf for leaf in unpairable_a
+    }
+    unpairable_b_by_id: dict[str, SyncNode] = {
+        leaf.node_id: leaf for leaf in unpairable_b
+    }
+    resolved_via_cache: set[str] = set()
+    resolved_a_ids: set[str] = set()
+    resolved_b_ids: set[str] = set()
+    for key, mapping in cached.items():
+        leaf_a_alt = unpairable_a_by_id.get(mapping.a_item_id)
+        leaf_b_alt = unpairable_b_by_id.get(mapping.b_item_id)
+        if leaf_a_alt is None or leaf_b_alt is None:
+            continue
+        fp_changed_a = (
+            mapping.fingerprint_a is not None
+            and leaf_a_alt.fingerprint != mapping.fingerprint_a
+        )
+        fp_changed_b = (
+            mapping.fingerprint_b is not None
+            and leaf_b_alt.fingerprint != mapping.fingerprint_b
+        )
+        if fp_changed_a or fp_changed_b:
+            leaf_ops.append(
+                SyncOp(
+                    op_type=OpType.MERGE_ITEM,
+                    target_side="both",
+                    node_id=leaf_a_alt.node_id,
+                    paired_node_id=leaf_b_alt.node_id,
+                    container_id_a=node_a.node_id,
+                    container_id_b=node_b.node_id,
+                    item_type=item_type,
+                    identity_key=key,
+                )
+            )
+        resolved_via_cache.add(key)
+        resolved_a_ids.add(leaf_a_alt.node_id)
+        resolved_b_ids.add(leaf_b_alt.node_id)
+    if resolved_via_cache:
+        unpairable_a = [
+            leaf for leaf in unpairable_a
+            if leaf.node_id not in resolved_a_ids
+        ]
+        unpairable_b = [
+            leaf for leaf in unpairable_b
+            if leaf.node_id not in resolved_b_ids
+        ]
+
     if leaves_a or leaves_b:
         paired_keys = set(by_identity_a) & set(by_identity_b)
         log.info(
             "pair %r: a=%d (keyed=%d, unpairable=%d), "
-            "b=%d (keyed=%d, unpairable=%d), paired_by_identity=%d, cache=%d",
+            "b=%d (keyed=%d, unpairable=%d), paired_by_identity=%d, "
+            "cache=%d, resolved_via_cache=%d",
             node_a.name,
             len(leaves_a), len(by_identity_a), len(unpairable_a),
             len(leaves_b), len(by_identity_b), len(unpairable_b),
-            len(paired_keys), len(cached),
+            len(paired_keys), len(cached), len(resolved_via_cache),
         )
 
     all_keys = set(by_identity_a) | set(by_identity_b) | set(cached)
     for key in sorted(all_keys):
+        if key in resolved_via_cache:
+            continue
         leaf_a = by_identity_a.get(key)
         leaf_b = by_identity_b.get(key)
         mapping = cached.get(key)

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -1009,10 +1009,16 @@ def _jmap_to_sync_item(event: dict[str, Any]) -> SyncItem:
         if exdates:
             fields["exdates"] = sorted(exdates)
 
-    # Participants — split into organizer and attendees
+    # Participants — split into organizer and attendees.
+    # Canonical shape (must match graph_adapter):
+    #   organizer: {"email": str, "name": str}
+    #   attendees: [{"email": str, "name": str, "role": str, "partstat": str}, ...]
+    # Extra JSCalendar fields (rsvp, role on organizer, etc.) are
+    # dropped because Graph does not expose them; keeping them here
+    # would make every paired event drift on the merge comparison.
     participants = event.get("participants")
     if participants and isinstance(participants, dict):
-        attendees: list[dict[str, Any]] = []
+        attendees: list[dict[str, str]] = []
         for _pid, p in participants.items():
             roles = p.get("roles", {})
             send_to = p.get("sendTo", {})
@@ -1020,30 +1026,25 @@ def _jmap_to_sync_item(event: dict[str, Any]) -> SyncItem:
             if email.lower().startswith("mailto:"):
                 email = email[7:]
 
-            entry: dict[str, Any] = {}
-            if email:
-                entry["email"] = email
-            if p.get("name"):
-                entry["name"] = p["name"]
-            if p.get("participationStatus"):
-                entry["status"] = p["participationStatus"]
-            if p.get("expectReply") is not None:
-                entry["rsvp"] = bool(p["expectReply"])
-
             if roles.get("owner"):
-                entry["role"] = "organizer"
-                fields["organizer"] = entry
+                fields["organizer"] = {
+                    "email": email or "",
+                    "name": p.get("name") or "",
+                }
+                continue
+
+            if roles.get("chair"):
+                role = "chair"
+            elif roles.get("optional"):
+                role = "optional"
             else:
-                # Determine role
-                if roles.get("attendee"):
-                    entry["role"] = "attendee"
-                elif roles.get("chair"):
-                    entry["role"] = "chair"
-                elif roles.get("optional"):
-                    entry["role"] = "optional"
-                else:
-                    entry["role"] = "attendee"
-                attendees.append(entry)
+                role = "attendee"
+            attendees.append({
+                "email": email or "",
+                "name": p.get("name") or "",
+                "role": role,
+                "partstat": p.get("participationStatus") or "needs-action",
+            })
 
         if attendees:
             fields["attendees"] = attendees
@@ -1246,10 +1247,6 @@ def _sync_item_to_jmap(item: SyncItem) -> dict[str, Any]:
                 p["sendTo"] = {"imip": f"mailto:{organizer['email']}"}
             if organizer.get("name"):
                 p["name"] = organizer["name"]
-            if organizer.get("status"):
-                p["participationStatus"] = organizer["status"]
-            if organizer.get("rsvp") is not None:
-                p["expectReply"] = bool(organizer["rsvp"])
             participants[f"p{idx}"] = p
             idx += 1
 
@@ -1267,10 +1264,8 @@ def _sync_item_to_jmap(item: SyncItem) -> dict[str, Any]:
                     p["sendTo"] = {"imip": f"mailto:{att['email']}"}
                 if att.get("name"):
                     p["name"] = att["name"]
-                if att.get("status"):
-                    p["participationStatus"] = att["status"]
-                if att.get("rsvp") is not None:
-                    p["expectReply"] = bool(att["rsvp"])
+                if att.get("partstat"):
+                    p["participationStatus"] = att["partstat"]
                 participants[f"p{idx}"] = p
                 idx += 1
 

--- a/src/groupware_sync_calendar/adapters/jmap_adapter.py
+++ b/src/groupware_sync_calendar/adapters/jmap_adapter.py
@@ -1272,7 +1272,9 @@ def _sync_item_to_jmap(item: SyncItem) -> dict[str, Any]:
         if participants:
             event["participants"] = participants
 
-    # Alerts (reminder)
+    # Alerts (reminder). Always set the field — null clears any orphan alerts
+    # left behind by other tools (e.g. malformed VALARM imports), since JMAP
+    # update is patch-based and would otherwise leave them untouched.
     reminder = fields.get("reminder_minutes")
     if reminder is not None:
         offset = _format_iso_duration(timedelta(minutes=-int(reminder)))
@@ -1286,6 +1288,8 @@ def _sync_item_to_jmap(item: SyncItem) -> dict[str, Any]:
                 "action": "display",
             },
         }
+    else:
+        event["alerts"] = None
 
     # URL -> links
     if fields.get("url"):

--- a/src/groupware_sync_calendar/specs.py
+++ b/src/groupware_sync_calendar/specs.py
@@ -29,9 +29,16 @@ CALENDAR_EVENT_SPEC = TypeSpec(
         FieldDef("privacy", MergeStrategy.SCALAR),
         FieldDef("free_busy", MergeStrategy.SCALAR),
         FieldDef("categories", MergeStrategy.SET),
-        FieldDef("sequence", MergeStrategy.SCALAR),
+        # sequence and updated are server-bumped on every PATCH (Graph
+        # bumps lastModifiedDateTime, JMAP bumps updated). They diverge
+        # between sides immediately after either side accepts a write,
+        # so treating them as user content makes every subsequent run
+        # report a conflict on every paired event. IGNORE keeps the
+        # raw fields out of the merge while updated_at on SyncItem
+        # still drives last-write-wins arbitration.
+        FieldDef("sequence", MergeStrategy.IGNORE),
         FieldDef("created", MergeStrategy.IMMUTABLE),
-        FieldDef("updated", MergeStrategy.SCALAR),
+        FieldDef("updated", MergeStrategy.IGNORE),
         # Reminders
         FieldDef("reminder_minutes", MergeStrategy.SCALAR),
         FieldDef("reminder_action", MergeStrategy.SCALAR),

--- a/src/groupware_sync_calendar/specs.py
+++ b/src/groupware_sync_calendar/specs.py
@@ -4,8 +4,13 @@ from groupware_sync.models import FieldDef, ItemType, MergeStrategy, TypeSpec
 CALENDAR_EVENT_SPEC = TypeSpec(
     item_type=ItemType.CALENDAR_EVENT,
     fields=[
-        # Identity
-        FieldDef("uid", MergeStrategy.IMMUTABLE),
+        # Identity. Ignored by the merge: Graph reassigns iCalUId on
+        # POST/PATCH (it's read-only) so we cannot roundtrip uid through
+        # Graph, and tree-level pairing already uses content_key as the
+        # primary identity. Treating uid as IMMUTABLE caused the engine
+        # to PATCH Graph with the Stalwart UID on every run, then read
+        # back Graph's reassigned UID, then drift on the next run.
+        FieldDef("uid", MergeStrategy.IGNORE),
         # Timing
         FieldDef("summary", MergeStrategy.SCALAR),
         FieldDef("description", MergeStrategy.SCALAR),
@@ -29,15 +34,16 @@ CALENDAR_EVENT_SPEC = TypeSpec(
         FieldDef("privacy", MergeStrategy.SCALAR),
         FieldDef("free_busy", MergeStrategy.SCALAR),
         FieldDef("categories", MergeStrategy.SET),
-        # sequence and updated are server-bumped on every PATCH (Graph
-        # bumps lastModifiedDateTime, JMAP bumps updated). They diverge
-        # between sides immediately after either side accepts a write,
-        # so treating them as user content makes every subsequent run
-        # report a conflict on every paired event. IGNORE keeps the
-        # raw fields out of the merge while updated_at on SyncItem
-        # still drives last-write-wins arbitration.
+        # sequence/updated/created are server-set timestamps. Each
+        # side maintains its own copy and refuses to overwrite (Graph's
+        # createdDateTime and lastModifiedDateTime are read-only;
+        # Stalwart sets its own at create-time and bumps `updated` on
+        # PATCH). Comparing them as user content guarantees drift on
+        # every run. IGNORE keeps them out of the merge entirely.
+        # SyncItem.updated_at (separate from the field copy) still
+        # drives last-write-wins arbitration.
         FieldDef("sequence", MergeStrategy.IGNORE),
-        FieldDef("created", MergeStrategy.IMMUTABLE),
+        FieldDef("created", MergeStrategy.IGNORE),
         FieldDef("updated", MergeStrategy.IGNORE),
         # Reminders
         FieldDef("reminder_minutes", MergeStrategy.SCALAR),

--- a/tests/test_calendar_participant_shape.py
+++ b/tests/test_calendar_participant_shape.py
@@ -1,0 +1,97 @@
+"""Regression: Graph and JMAP adapters must produce identical organizer
+and attendees shapes. If they diverge, merge_item sees the dicts as
+unequal and PATCHes both sides on every run, causing perpetual drift
+on `organizer` and `attendees`."""
+from groupware_sync_calendar.adapters.graph_adapter import _graph_to_sync_item
+from groupware_sync_calendar.adapters.jmap_adapter import _jmap_to_sync_item
+
+
+def test_organizer_shape_matches_between_adapters():
+    graph_event = {
+        "id": "g1",
+        "iCalUId": "uid-1",
+        "subject": "Meeting",
+        "organizer": {
+            "emailAddress": {"address": "alice@example.com", "name": "Alice"},
+        },
+        "start": {"dateTime": "2026-04-23T10:00:00.0000000", "timeZone": "UTC"},
+        "end": {"dateTime": "2026-04-23T11:00:00.0000000", "timeZone": "UTC"},
+    }
+    graph_item = _graph_to_sync_item(graph_event)
+
+    jmap_event = {
+        "id": "j1",
+        "uid": "uid-1",
+        "title": "Meeting",
+        "participants": {
+            "p0": {
+                "@type": "Participant",
+                "roles": {"owner": True, "attendee": True},
+                "sendTo": {"imip": "mailto:alice@example.com"},
+                "name": "Alice",
+                "participationStatus": "accepted",
+                "expectReply": False,
+            },
+        },
+        "start": "2026-04-23T10:00:00",
+        "timeZone": "Etc/UTC",
+        "duration": "PT1H",
+    }
+    jmap_fields = _jmap_to_sync_item(jmap_event).fields
+
+    assert graph_item.fields["organizer"] == jmap_fields["organizer"]
+    assert set(graph_item.fields["organizer"].keys()) == {"email", "name"}
+
+
+def test_attendees_shape_matches_between_adapters():
+    graph_event = {
+        "id": "g1",
+        "iCalUId": "uid-1",
+        "subject": "Meeting",
+        "attendees": [
+            {
+                "emailAddress": {"address": "bob@example.com", "name": "Bob"},
+                "type": "required",
+                "status": {"response": "accepted"},
+            },
+            {
+                "emailAddress": {"address": "carol@example.com", "name": "Carol"},
+                "type": "optional",
+                "status": {"response": "tentativelyAccepted"},
+            },
+        ],
+        "start": {"dateTime": "2026-04-23T10:00:00.0000000", "timeZone": "UTC"},
+        "end": {"dateTime": "2026-04-23T11:00:00.0000000", "timeZone": "UTC"},
+    }
+    graph_item = _graph_to_sync_item(graph_event)
+
+    jmap_event = {
+        "id": "j1",
+        "uid": "uid-1",
+        "title": "Meeting",
+        "participants": {
+            "p0": {
+                "@type": "Participant",
+                "roles": {"attendee": True},
+                "sendTo": {"imip": "mailto:bob@example.com"},
+                "name": "Bob",
+                "participationStatus": "accepted",
+            },
+            "p1": {
+                "@type": "Participant",
+                "roles": {"optional": True},
+                "sendTo": {"imip": "mailto:carol@example.com"},
+                "name": "Carol",
+                "participationStatus": "tentative",
+            },
+        },
+        "start": "2026-04-23T10:00:00",
+        "timeZone": "Etc/UTC",
+        "duration": "PT1H",
+    }
+    jmap_fields = _jmap_to_sync_item(jmap_event).fields
+
+    graph_atts = sorted(graph_item.fields["attendees"], key=lambda a: a["email"])
+    jmap_atts = sorted(jmap_fields["attendees"], key=lambda a: a["email"])
+    assert graph_atts == jmap_atts
+    assert all(set(a.keys()) == {"email", "name", "role", "partstat"} for a in graph_atts)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -108,3 +108,31 @@ def test_neither_changed():
     assert c_a is False
     assert c_b is False
     assert conflicts == 0
+
+
+def test_calendar_metadata_fields_ignored():
+    """Regression: server-bumped `updated`/`sequence` must not register
+    as conflicts. Without IGNORE they made every paired event report
+    a conflict on every run because Graph and JMAP each bump their
+    own copy after a write."""
+    from groupware_sync_calendar.specs import CALENDAR_EVENT_SPEC
+
+    base = {
+        "uid": "evt-1",
+        "summary": "Standup",
+        "dtstart_utc": "2026-04-23T09:00:00Z",
+    }
+    a = SyncItem(
+        "a1", ItemType.CALENDAR_EVENT,
+        {**base, "updated": "2026-04-23T10:00:00Z", "sequence": 5},
+        updated_at=TS_A,
+    )
+    b = SyncItem(
+        "b1", ItemType.CALENDAR_EVENT,
+        {**base, "updated": "2026-04-23T09:00:00Z", "sequence": 3},
+        updated_at=TS_B,
+    )
+    merged, _, _, conflicts = merge_item(a, b, None, CALENDAR_EVENT_SPEC)
+    assert conflicts == 0
+    assert "updated" not in merged.fields
+    assert "sequence" not in merged.fields

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -28,7 +28,7 @@ def test_scalar_a_changed_b_didnt():
     prev = SyncItem("x", ItemType.CONTACT, {"full_name": "Alice", "emails": [], "uid": "u1"})
     a = SyncItem("a1", ItemType.CONTACT, {"full_name": "Alice New", "emails": [], "uid": "u1"}, updated_at=TS_A)
     b = SyncItem("b1", ItemType.CONTACT, {"full_name": "Alice", "emails": [], "uid": "u1"}, updated_at=TS_B)
-    merged, c_a, c_b, conflicts = merge_item(a, b, prev, SIMPLE_SPEC)
+    merged, c_a, c_b, conflicts, _ = merge_item(a, b, prev, SIMPLE_SPEC)
     assert merged.fields["full_name"] == "Alice New"
     assert c_a is False
     assert c_b is True
@@ -39,7 +39,7 @@ def test_scalar_b_changed_a_didnt():
     prev = SyncItem("x", ItemType.CONTACT, {"full_name": "Alice", "emails": [], "uid": "u1"})
     a = SyncItem("a1", ItemType.CONTACT, {"full_name": "Alice", "emails": [], "uid": "u1"}, updated_at=TS_A)
     b = SyncItem("b1", ItemType.CONTACT, {"full_name": "Alice Updated", "emails": [], "uid": "u1"}, updated_at=TS_B)
-    merged, c_a, c_b, conflicts = merge_item(a, b, prev, SIMPLE_SPEC)
+    merged, c_a, c_b, conflicts, _ = merge_item(a, b, prev, SIMPLE_SPEC)
     assert merged.fields["full_name"] == "Alice Updated"
     assert c_a is True
     assert c_b is False
@@ -49,7 +49,7 @@ def test_scalar_both_changed_same_value():
     prev = SyncItem("x", ItemType.CONTACT, {"full_name": "Alice", "emails": [], "uid": "u1"})
     a = SyncItem("a1", ItemType.CONTACT, {"full_name": "Bob", "emails": [], "uid": "u1"}, updated_at=TS_A)
     b = SyncItem("b1", ItemType.CONTACT, {"full_name": "Bob", "emails": [], "uid": "u1"}, updated_at=TS_B)
-    merged, c_a, c_b, conflicts = merge_item(a, b, prev, SIMPLE_SPEC)
+    merged, c_a, c_b, conflicts, _ = merge_item(a, b, prev, SIMPLE_SPEC)
     assert merged.fields["full_name"] == "Bob"
     assert conflicts == 0
 
@@ -58,7 +58,7 @@ def test_scalar_conflict_a_wins_newer():
     prev = SyncItem("x", ItemType.CONTACT, {"full_name": "Alice", "emails": [], "uid": "u1"})
     a = SyncItem("a1", ItemType.CONTACT, {"full_name": "Alice A", "emails": [], "uid": "u1"}, updated_at=TS_A)
     b = SyncItem("b1", ItemType.CONTACT, {"full_name": "Alice B", "emails": [], "uid": "u1"}, updated_at=TS_B)
-    merged, c_a, c_b, conflicts = merge_item(a, b, prev, SIMPLE_SPEC)
+    merged, c_a, c_b, conflicts, _ = merge_item(a, b, prev, SIMPLE_SPEC)
     assert merged.fields["full_name"] == "Alice A"  # A is newer
     assert conflicts == 1
 
@@ -67,7 +67,7 @@ def test_scalar_conflict_b_wins_newer():
     prev = SyncItem("x", ItemType.CONTACT, {"full_name": "Alice", "emails": [], "uid": "u1"})
     a = SyncItem("a1", ItemType.CONTACT, {"full_name": "Alice A", "emails": [], "uid": "u1"}, updated_at=TS_B)  # older
     b = SyncItem("b1", ItemType.CONTACT, {"full_name": "Alice B", "emails": [], "uid": "u1"}, updated_at=TS_A)  # newer
-    merged, c_a, c_b, conflicts = merge_item(a, b, prev, SIMPLE_SPEC)
+    merged, c_a, c_b, conflicts, _ = merge_item(a, b, prev, SIMPLE_SPEC)
     assert merged.fields["full_name"] == "Alice B"
 
 
@@ -75,7 +75,7 @@ def test_no_snapshot_uses_timestamp():
     """Without a snapshot, every field is treated as 'both changed'."""
     a = SyncItem("a1", ItemType.CONTACT, {"full_name": "Alice A", "emails": [], "uid": "u1"}, updated_at=TS_A)
     b = SyncItem("b1", ItemType.CONTACT, {"full_name": "Alice B", "emails": [], "uid": "u1"}, updated_at=TS_B)
-    merged, _, _, conflicts = merge_item(a, b, None, SIMPLE_SPEC)
+    merged, _, _, conflicts, _ = merge_item(a, b, None, SIMPLE_SPEC)
     assert merged.fields["full_name"] == "Alice A"  # A newer wins
     assert conflicts == 1
 
@@ -84,7 +84,7 @@ def test_immutable_field_kept():
     prev = SyncItem("x", ItemType.CONTACT, {"full_name": "A", "emails": [], "uid": "original"})
     a = SyncItem("a1", ItemType.CONTACT, {"full_name": "A", "emails": [], "uid": "original"}, updated_at=TS_A)
     b = SyncItem("b1", ItemType.CONTACT, {"full_name": "A", "emails": [], "uid": "original"}, updated_at=TS_B)
-    merged, _, _, _ = merge_item(a, b, prev, SIMPLE_SPEC)
+    merged, _, _, _, _ = merge_item(a, b, prev, SIMPLE_SPEC)
     assert merged.fields["uid"] == "original"
 
 
@@ -92,7 +92,7 @@ def test_set_merge_union_additions():
     prev = SyncItem("x", ItemType.CONTACT, {"full_name": "A", "emails": ["a@b.com"], "uid": "u"})
     a = SyncItem("a1", ItemType.CONTACT, {"full_name": "A", "emails": ["a@b.com", "new_a@b.com"], "uid": "u"}, updated_at=TS_A)
     b = SyncItem("b1", ItemType.CONTACT, {"full_name": "A", "emails": ["a@b.com", "new_b@b.com"], "uid": "u"}, updated_at=TS_B)
-    merged, c_a, c_b, _ = merge_item(a, b, prev, SIMPLE_SPEC)
+    merged, c_a, c_b, _, _ = merge_item(a, b, prev, SIMPLE_SPEC)
     emails = merged.fields["emails"]
     assert "a@b.com" in emails
     assert "new_a@b.com" in emails
@@ -103,7 +103,7 @@ def test_neither_changed():
     prev = SyncItem("x", ItemType.CONTACT, {"full_name": "Same", "emails": [], "uid": "u"})
     a = SyncItem("a1", ItemType.CONTACT, {"full_name": "Same", "emails": [], "uid": "u"}, updated_at=TS_A)
     b = SyncItem("b1", ItemType.CONTACT, {"full_name": "Same", "emails": [], "uid": "u"}, updated_at=TS_B)
-    merged, c_a, c_b, conflicts = merge_item(a, b, prev, SIMPLE_SPEC)
+    merged, c_a, c_b, conflicts, _ = merge_item(a, b, prev, SIMPLE_SPEC)
     assert merged.fields["full_name"] == "Same"
     assert c_a is False
     assert c_b is False
@@ -132,7 +132,7 @@ def test_calendar_metadata_fields_ignored():
         {**base, "updated": "2026-04-23T09:00:00Z", "sequence": 3},
         updated_at=TS_B,
     )
-    merged, _, _, conflicts = merge_item(a, b, None, CALENDAR_EVENT_SPEC)
+    merged, _, _, conflicts, _ = merge_item(a, b, None, CALENDAR_EVENT_SPEC)
     assert conflicts == 0
     assert "updated" not in merged.fields
     assert "sequence" not in merged.fields
@@ -153,7 +153,7 @@ def test_set_field_none_on_both_sides_not_changed():
         {"full_name": "Alice", "uid": "u1"},
         updated_at=TS_B,
     )
-    _merged, changed_vs_a, changed_vs_b, conflicts = merge_item(a, b, None, SIMPLE_SPEC)
+    _merged, changed_vs_a, changed_vs_b, conflicts, _ = merge_item(a, b, None, SIMPLE_SPEC)
     assert conflicts == 0
     assert changed_vs_a is False
     assert changed_vs_b is False
@@ -173,7 +173,7 @@ def test_set_field_same_content_different_order_not_changed():
         {"full_name": "Alice", "uid": "u1", "emails": ["z@y.com", "x@y.com"]},
         updated_at=TS_B,
     )
-    _merged, changed_vs_a, changed_vs_b, conflicts = merge_item(a, b, None, SIMPLE_SPEC)
+    _merged, changed_vs_a, changed_vs_b, conflicts, _ = merge_item(a, b, None, SIMPLE_SPEC)
     assert conflicts == 0
     assert changed_vs_a is False
     assert changed_vs_b is False
@@ -192,7 +192,7 @@ def test_set_field_a_has_none_b_has_empty_list_not_changed():
         {"full_name": "Alice", "uid": "u1", "emails": []},
         updated_at=TS_B,
     )
-    _merged, changed_vs_a, changed_vs_b, conflicts = merge_item(a, b, None, SIMPLE_SPEC)
+    _merged, changed_vs_a, changed_vs_b, conflicts, _ = merge_item(a, b, None, SIMPLE_SPEC)
     assert conflicts == 0
     assert changed_vs_a is False
     assert changed_vs_b is False

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -136,3 +136,63 @@ def test_calendar_metadata_fields_ignored():
     assert conflicts == 0
     assert "updated" not in merged.fields
     assert "sequence" not in merged.fields
+
+
+def test_set_field_none_on_both_sides_not_changed():
+    """Regression: when both adapters omit a SET field (e.g. attendees=None
+    because the event has no attendees), the merged result is [] but the
+    inputs are None. The pre-fix dict-equality check flagged this as
+    changed_vs_a/b=True, causing every paired event to PATCH on every run."""
+    a = SyncItem(
+        "a1", ItemType.CONTACT,
+        {"full_name": "Alice", "uid": "u1"},
+        updated_at=TS_A,
+    )
+    b = SyncItem(
+        "b1", ItemType.CONTACT,
+        {"full_name": "Alice", "uid": "u1"},
+        updated_at=TS_B,
+    )
+    _merged, changed_vs_a, changed_vs_b, conflicts = merge_item(a, b, None, SIMPLE_SPEC)
+    assert conflicts == 0
+    assert changed_vs_a is False
+    assert changed_vs_b is False
+
+
+def test_set_field_same_content_different_order_not_changed():
+    """Regression: SET fields must compare as sets, not lists. Adapters
+    may return the same content in different orders; that should not
+    trigger an update."""
+    a = SyncItem(
+        "a1", ItemType.CONTACT,
+        {"full_name": "Alice", "uid": "u1", "emails": ["x@y.com", "z@y.com"]},
+        updated_at=TS_A,
+    )
+    b = SyncItem(
+        "b1", ItemType.CONTACT,
+        {"full_name": "Alice", "uid": "u1", "emails": ["z@y.com", "x@y.com"]},
+        updated_at=TS_B,
+    )
+    _merged, changed_vs_a, changed_vs_b, conflicts = merge_item(a, b, None, SIMPLE_SPEC)
+    assert conflicts == 0
+    assert changed_vs_a is False
+    assert changed_vs_b is False
+
+
+def test_set_field_a_has_none_b_has_empty_list_not_changed():
+    """Regression: one adapter may omit the field (None) and the other
+    may emit an empty list. Both mean 'no values'."""
+    a = SyncItem(
+        "a1", ItemType.CONTACT,
+        {"full_name": "Alice", "uid": "u1"},
+        updated_at=TS_A,
+    )
+    b = SyncItem(
+        "b1", ItemType.CONTACT,
+        {"full_name": "Alice", "uid": "u1", "emails": []},
+        updated_at=TS_B,
+    )
+    _merged, changed_vs_a, changed_vs_b, conflicts = merge_item(a, b, None, SIMPLE_SPEC)
+    assert conflicts == 0
+    assert changed_vs_a is False
+    assert changed_vs_b is False

--- a/tests/test_tree_resolve_unpairable_via_cache.py
+++ b/tests/test_tree_resolve_unpairable_via_cache.py
@@ -1,0 +1,173 @@
+"""Two leaves on each side share a content_key (identity_key collision).
+A previous run paired them via the execute-time fallback and stored
+ItemMappings under `_legacy_identity_key(a_id, b_id)`. The next run's
+`_bucket` demotes them to unpairable again because they still collide
+on identity_key — but the cached mappings record the actual pairing.
+The tree must trust the cached mappings and avoid the CREATE+DELETE
+churn cycle.
+
+Without the fix, a stable pair of collisions plans:
+  - DELETE_ITEM target_side='both' for each cached mapping
+    (because no leaf has the legacy identity_key)
+  - CREATE_ITEM for each unpairable leaf
+on every sync, forever — even though the data is stable."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from groupware_sync.models import ItemType, NodeType, OpType, SyncNode
+from groupware_sync.state import ops as state_ops
+from groupware_sync.state.db import make_session_factory
+from groupware_sync.tree import compare_trees
+
+
+@pytest.fixture
+def session():
+    db_path = "test_tree_cache_resolve.db"
+    sf = make_session_factory(f"sqlite:///{db_path}")
+    s = sf()
+    yield s
+    s.close()
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+
+def _tree_with_collision_pair(
+    a_ids: list[tuple[str, str, str]],
+    b_ids: list[tuple[str, str, str]],
+) -> tuple[SyncNode, SyncNode]:
+    """Build two trees, one container each. Each leaf is (node_id,
+    identity_key, fingerprint). Use the same identity_key on multiple
+    leaves to simulate a content_key collision."""
+    a_leaves = [
+        SyncNode(nid, nid, NodeType.LEAF, fingerprint=fp,
+                 identity_key=ik, item_type=ItemType.CONTACT)
+        for nid, ik, fp in a_ids
+    ]
+    b_leaves = [
+        SyncNode(nid, nid, NodeType.LEAF, fingerprint=fp,
+                 identity_key=ik, item_type=ItemType.CONTACT)
+        for nid, ik, fp in b_ids
+    ]
+    a = SyncNode("root", "root", NodeType.CONTAINER, children=[
+        SyncNode("c", "c", NodeType.CONTAINER, children=a_leaves),
+    ])
+    b = SyncNode("root", "root", NodeType.CONTAINER, children=[
+        SyncNode("c", "c", NodeType.CONTAINER, children=b_leaves),
+    ])
+    a.compute_merkle()
+    b.compute_merkle()
+    return a, b
+
+
+def test_collision_pairs_with_cached_mapping_emit_no_ops(session):
+    """Steady-state regression: two paired leaves on each side share
+    identity_key, both ItemMappings exist with legacy keys, fingerprints
+    haven't drifted → tree must emit zero CREATE/DELETE/MERGE ops."""
+    pair = state_ops.get_or_create_pair(
+        session, ItemType.CONTACT.value, "prov_a", "c", "prov_b", "c", "",
+    )
+    state_ops.create_mapping(
+        session, pair.id,
+        a_item_id="a1", b_item_id="b1",
+        identity_key="legacy|a1|b1",
+        fingerprint_a="fp1", fingerprint_b="fp1",
+    )
+    state_ops.create_mapping(
+        session, pair.id,
+        a_item_id="a2", b_item_id="b2",
+        identity_key="legacy|a2|b2",
+        fingerprint_a="fp2", fingerprint_b="fp2",
+    )
+    session.commit()
+
+    a, b = _tree_with_collision_pair(
+        a_ids=[("a1", "ik:shared", "fp1"), ("a2", "ik:shared", "fp2")],
+        b_ids=[("b1", "ik:shared", "fp1"), ("b2", "ik:shared", "fp2")],
+    )
+
+    ops_list, _ = compare_trees(
+        a, b, "prov_a", "prov_b", ItemType.CONTACT, session,
+    )
+
+    creates = [op for op in ops_list if op.op_type == OpType.CREATE_ITEM]
+    deletes = [op for op in ops_list if op.op_type == OpType.DELETE_ITEM]
+    merges = [op for op in ops_list if op.op_type == OpType.MERGE_ITEM]
+    assert creates == [], f"unexpected creates: {creates}"
+    assert deletes == [], f"unexpected deletes: {deletes}"
+    assert merges == [], f"unexpected merges: {merges}"
+
+
+def test_collision_pair_with_drifted_fingerprint_emits_merge(session):
+    """When fingerprints drifted on either side, the cache-resolved
+    pair gets a MERGE_ITEM op so the engine can converge — but still
+    no CREATE or DELETE for that pair."""
+    pair = state_ops.get_or_create_pair(
+        session, ItemType.CONTACT.value, "prov_a", "c", "prov_b", "c", "",
+    )
+    state_ops.create_mapping(
+        session, pair.id,
+        a_item_id="a1", b_item_id="b1",
+        identity_key="legacy|a1|b1",
+        fingerprint_a="fp1-old", fingerprint_b="fp1-old",
+    )
+    session.commit()
+
+    a, b = _tree_with_collision_pair(
+        a_ids=[("a1", "ik:shared", "fp1-NEW"), ("a2", "ik:shared", "fp2")],
+        b_ids=[("b1", "ik:shared", "fp1-old"), ("b2", "ik:shared", "fp2")],
+    )
+
+    ops_list, _ = compare_trees(
+        a, b, "prov_a", "prov_b", ItemType.CONTACT, session,
+    )
+
+    merges = [op for op in ops_list if op.op_type == OpType.MERGE_ITEM]
+    creates = [op for op in ops_list if op.op_type == OpType.CREATE_ITEM]
+    deletes = [op for op in ops_list if op.op_type == OpType.DELETE_ITEM]
+    assert len(merges) == 1
+    assert merges[0].node_id == "a1"
+    assert merges[0].paired_node_id == "b1"
+    # a2/b2 have no cached mapping → standard unpairable handling.
+    assert {op.node_id for op in creates} == {"a2", "b2"}
+    assert deletes == []
+
+
+def test_cached_mapping_with_one_side_gone_still_cleaned_up(session):
+    """The fix targets stable cached pairs only. When one leaf is
+    genuinely gone but the cache still records it, normal cleanup
+    must still run."""
+    pair = state_ops.get_or_create_pair(
+        session, ItemType.CONTACT.value, "prov_a", "c", "prov_b", "c", "",
+    )
+    state_ops.create_mapping(
+        session, pair.id,
+        a_item_id="a1", b_item_id="b1",
+        identity_key="legacy|a1|b1",
+        fingerprint_a="fp1", fingerprint_b="fp1",
+    )
+    session.commit()
+
+    # b1 has been deleted; only a1 remains on side A. No collision now.
+    a, b = _tree_with_collision_pair(
+        a_ids=[("a1", "ik:lone", "fp1")],
+        b_ids=[],
+    )
+
+    ops_list, _ = compare_trees(
+        a, b, "prov_a", "prov_b", ItemType.CONTACT, session,
+    )
+    # a1 has identity_key="ik:lone" (in by_identity_a), not in any
+    # cached mapping (the cached one is "legacy|a1|b1"). So a1 takes
+    # the standard "leaf_a exists, leaf_b None, no mapping" path →
+    # CREATE_ITEM on B. The cached mapping (no leaves at "legacy|a1|b1")
+    # gets cleaned up as `(both gone)`.
+    create_b = [op for op in ops_list
+                if op.op_type == OpType.CREATE_ITEM and op.target_side == "b"]
+    delete_both = [op for op in ops_list
+                   if op.op_type == OpType.DELETE_ITEM and op.target_side == "both"]
+    assert len(create_b) == 1
+    assert create_b[0].node_id == "a1"
+    assert len(delete_both) == 1

--- a/tests/test_tree_resolve_unpairable_via_cache.py
+++ b/tests/test_tree_resolve_unpairable_via_cache.py
@@ -13,10 +13,9 @@ Without the fix, a stable pair of collisions plans:
 on every sync, forever — even though the data is stable."""
 from __future__ import annotations
 
-import os
-
 import pytest
 
+from groupware_sync.engine import _legacy_identity_key
 from groupware_sync.models import ItemType, NodeType, OpType, SyncNode
 from groupware_sync.state import ops as state_ops
 from groupware_sync.state.db import make_session_factory
@@ -24,14 +23,11 @@ from groupware_sync.tree import compare_trees
 
 
 @pytest.fixture
-def session():
-    db_path = "test_tree_cache_resolve.db"
-    sf = make_session_factory(f"sqlite:///{db_path}")
+def session(tmp_path):
+    sf = make_session_factory(f"sqlite:///{tmp_path / 'test.db'}")
     s = sf()
     yield s
     s.close()
-    if os.path.exists(db_path):
-        os.remove(db_path)
 
 
 def _tree_with_collision_pair(
@@ -72,13 +68,13 @@ def test_collision_pairs_with_cached_mapping_emit_no_ops(session):
     state_ops.create_mapping(
         session, pair.id,
         a_item_id="a1", b_item_id="b1",
-        identity_key="legacy|a1|b1",
+        identity_key=_legacy_identity_key("a1", "b1"),
         fingerprint_a="fp1", fingerprint_b="fp1",
     )
     state_ops.create_mapping(
         session, pair.id,
         a_item_id="a2", b_item_id="b2",
-        identity_key="legacy|a2|b2",
+        identity_key=_legacy_identity_key("a2", "b2"),
         fingerprint_a="fp2", fingerprint_b="fp2",
     )
     session.commit()
@@ -110,7 +106,7 @@ def test_collision_pair_with_drifted_fingerprint_emits_merge(session):
     state_ops.create_mapping(
         session, pair.id,
         a_item_id="a1", b_item_id="b1",
-        identity_key="legacy|a1|b1",
+        identity_key=_legacy_identity_key("a1", "b1"),
         fingerprint_a="fp1-old", fingerprint_b="fp1-old",
     )
     session.commit()
@@ -145,7 +141,7 @@ def test_cached_mapping_with_one_side_gone_still_cleaned_up(session):
     state_ops.create_mapping(
         session, pair.id,
         a_item_id="a1", b_item_id="b1",
-        identity_key="legacy|a1|b1",
+        identity_key=_legacy_identity_key("a1", "b1"),
         fingerprint_a="fp1", fingerprint_b="fp1",
     )
     session.commit()
@@ -160,10 +156,10 @@ def test_cached_mapping_with_one_side_gone_still_cleaned_up(session):
         a, b, "prov_a", "prov_b", ItemType.CONTACT, session,
     )
     # a1 has identity_key="ik:lone" (in by_identity_a), not in any
-    # cached mapping (the cached one is "legacy|a1|b1"). So a1 takes
-    # the standard "leaf_a exists, leaf_b None, no mapping" path →
-    # CREATE_ITEM on B. The cached mapping (no leaves at "legacy|a1|b1")
-    # gets cleaned up as `(both gone)`.
+    # cached mapping (the cached one is _legacy_identity_key("a1","b1")).
+    # So a1 takes the standard "leaf_a exists, leaf_b None, no mapping"
+    # path → CREATE_ITEM on B. The cached mapping (no leaves at the
+    # legacy key) gets cleaned up as `(both gone)`.
     create_b = [op for op in ops_list
                 if op.op_type == OpType.CREATE_ITEM and op.target_side == "b"]
     delete_both = [op for op in ops_list


### PR DESCRIPTION
## Summary

Three fixes that together get the bidirectional Graph ↔ Stalwart calendar sync to a real steady state. Before: every dry-run planned ~58 creates and ~29 deletes; every live run reported `updated=29` (first with `conflicts=29`, then with `conflicts=0` but still patching). After: zero churn.

## Fix 1: tree resolves unpairable leaves via cached provider-id mapping

Stable runs still planned ~58 creates and ~29 deletes on every dry-run despite the data being unchanged.

### The churn cycle (before)

1. **Tree-build:** ~60 events on each side share `content_key` (e.g. "Lunch" appearing twice in Outlook on the same day). `_bucket` correctly demotes them to "unpairable" — first-wins would risk silently miss-pairing.
2. **`_execute_creates`:** fetches full items, runs `_identity_match`, and pairs them by uid at execute time. The resulting `ItemMapping` is stored under `_legacy_identity_key(a_id, b_id)`, not the leaves' identity_keys.
3. **Next run's tree-build:** leaves still collide on identity_key → still unpairable. Cached legacy mappings carry keys no leaf has → the main key loop sees them as `"neither side has it, mapping does"` → `DELETE_ITEM target_side='both'` for cache cleanup.
4. **Unpairable leaves:** get `CREATE_ITEM` → execute re-pairs → stores new legacy mappings. Goto 3.

### Fix

Before the main key-iteration loop, walk cached mappings and resolve any whose `a_item_id` and `b_item_id` are **both** still present in the unpairable buckets. Treat them as paired-via-cache:

- Emit `MERGE_ITEM` only when fingerprints drifted; otherwise emit nothing.
- Mark the cached `identity_key` as resolved so the main loop's both-gone path skips it.
- Remove the leaves from the unpairable buckets so they don't get re-`CREATE`d below.

## Fix 2: IGNORE server-bumped sequence/updated fields

After Fix 1, every paired event still reported a conflict on every run: `conflicts=29 updated=29` with no actual content change.

Graph and JMAP each bump their own `sequence` / `lastModifiedDateTime` on every PATCH, so the two sides diverge on those fields immediately after a write. With both fields marked `SCALAR`, `merge_item` saw them as "both changed, different values" → conflict + last-write-wins on every paired event, every run.

Marking `sequence` and `updated` as `IGNORE` keeps these metadata fields out of the merge entirely. Last-write-wins arbitration still works through `SyncItem.updated_at`, which is set independently from the field copy.

## Fix 3: track changed_vs_a/b per field, not via final dict equality

After Fix 2, conflicts dropped to 0 but `updated=29` persisted. Two SET-related issues triggered spurious PATCHes:

1. Both adapters guard `if attendees:` / `if categories:` etc., so an event with no attendees has `fields["attendees"] is None` on both sides. `_merge_set(None, None, None, True, True)` produces `[]`. The pre-fix dict-equality check then saw `merged["attendees"]=[]` vs `item_a.fields["attendees"]=None` → `changed_vs_a=True`.
2. `_merge_set` returns elements in Python set-iteration order. When both sides hold identical content in different list orders, the dict equality flags it as changed even though the set content matches.

`_merge_set` already returned correct set-based `changed_vs_a / changed_vs_b` flags — `merge_item` just discarded them. Fix: track changed flags per-field as the merge runs:

- IMMUTABLE / SCALAR compare the merged value to `val_a` / `val_b`
- SET uses the flags `_merge_set` returned (set-based, so order- and None-vs-[]-insensitive)

## Test plan

- [x] `pytest tests/test_tree_resolve_unpairable_via_cache.py -v` — 3 regression tests for Fix 1.
- [x] `pytest tests/test_merge.py::test_calendar_metadata_fields_ignored -v` — regression for Fix 2.
- [x] `pytest tests/test_merge.py -k "set_field"` — 3 new regressions for Fix 3 (None-on-both, order, None-vs-empty-list).
- [x] `pytest -m "not e2e" -q` — 219 passed, no regressions.
- [x] `ruff check` — clean.
- [ ] On merge: re-run live sync. Expected `created=0 updated=0 deleted=0 conflicts=0 errors=0` — true steady state.