### PR TITLE
fix: address audit findings #20, #21, #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ groupware-sync-contacts sync --dry-run --verbose
 groupware-sync-contacts sync --verbose
 ```
 
+### 3. Selecting a backend per side
+
+By default side A is Stalwart (JMAP) and side B is Microsoft 365 (Graph). To
+sync against a CardDAV or CalDAV server instead, set the per-side backend
+selector and provide DAV credentials for that side:
+
+```bash
+# Replace side B (the M365 side) with a CardDAV server:
+export SYNC_SIDE_B_BACKEND=carddav   # or pass --side-b-backend carddav
+export SYNC_SIDE_B_DAV_URL=https://radicale.example.org
+export SYNC_SIDE_B_DAV_USERNAME=alice
+export SYNC_SIDE_B_DAV_PASSWORD=...
+
+groupware-sync-contacts sync --verbose
+```
+
+| Side | Backend selector value | Required env vars |
+|---|---|---|
+| Stalwart JMAP | `jmap` *(default for side A)* | `SYNC_STALWART_*`, `SYNC_STALWART_JMAP_URL` |
+| Microsoft Graph | `graph` *(default for side B)* | `SYNC_M365_*` |
+| CardDAV / CalDAV | `carddav` / `caldav` | `SYNC_SIDE_{A,B}_DAV_URL`, `SYNC_SIDE_{A,B}_DAV_USERNAME`, `SYNC_SIDE_{A,B}_DAV_PASSWORD` |
+
+The contacts CLI accepts `jmap`, `graph`, and `carddav`. The calendar CLI
+accepts `jmap`, `graph`, and `caldav`. CLI flags `--side-a-backend` and
+`--side-b-backend` override the env vars for one-off invocations.
+
 ## Testing
 
 Unit tests (no external dependencies):

--- a/src/groupware_sync/config.py
+++ b/src/groupware_sync/config.py
@@ -8,6 +8,13 @@ from typing import Optional
 
 DEFAULT_STATE_DB = Path.home() / ".local" / "share" / "groupware-sync" / "sync.db"
 
+# Backend identifiers accepted by SYNC_SIDE_A_BACKEND / SYNC_SIDE_B_BACKEND
+# and the matching CLI flags. The contacts CLI accepts {jmap, graph, carddav};
+# the calendar CLI accepts {jmap, graph, caldav}. Validation lives at the
+# call site (the framework Config doesn't know which CLI is loading it).
+CONTACT_BACKENDS = {"jmap", "graph", "carddav"}
+CALENDAR_BACKENDS = {"jmap", "graph", "caldav"}
+
 
 @dataclass
 class ProviderConfig:
@@ -17,8 +24,25 @@ class ProviderConfig:
 
 
 @dataclass
+class DavConfig:
+    """Connection details for a CardDAV or CalDAV side.
+
+    Populated from `SYNC_SIDE_{A,B}_DAV_*` env vars. None when the matching
+    side's backend is not carddav/caldav.
+    """
+    base_url: str
+    username: str
+    password: str
+
+
+@dataclass
 class Config:
     sync_type: str
+    # Per-side backend selectors. Defaults preserve the original
+    # M365 (Graph) ↔ Stalwart (JMAP) topology so existing deployments are
+    # unaffected by the introduction of these fields.
+    side_a_backend: str  # "jmap" by default
+    side_b_backend: str  # "graph" by default
     stalwart: ProviderConfig
     stalwart_jmap_url: str
     stalwart_addressbook: Optional[str]
@@ -26,6 +50,10 @@ class Config:
     m365: ProviderConfig
     m365_addressbook: Optional[str]
     m365_calendar: Optional[str]
+    # Side-specific DAV connection details. Only consulted when the matching
+    # side's backend is "carddav" or "caldav".
+    side_a_dav: Optional[DavConfig]
+    side_b_dav: Optional[DavConfig]
     state_database_url: str
 
     @classmethod
@@ -36,23 +64,63 @@ class Config:
                 raise ValueError(f"missing required env var: {name}")
             return val
 
+        side_a_backend = os.environ.get("SYNC_SIDE_A_BACKEND", "jmap").lower()
+        side_b_backend = os.environ.get("SYNC_SIDE_B_BACKEND", "graph").lower()
+
+        # Stalwart and M365 OAuth config is only required when the matching
+        # backend is selected. To keep the env-var schema unchanged for the
+        # default jmap/graph topology, we still require them under the
+        # default selectors but treat them as optional otherwise.
+        def maybe_provider(env_prefix: str, when: bool) -> ProviderConfig:
+            if when:
+                return ProviderConfig(
+                    auth_database_url=req(f"{env_prefix}_AUTH_DATABASE_URL"),
+                    auth_uid=req(f"{env_prefix}_AUTH_UID"),
+                    auth_provider_name=req(f"{env_prefix}_AUTH_PROVIDER_NAME"),
+                )
+            return ProviderConfig(
+                auth_database_url=os.environ.get(f"{env_prefix}_AUTH_DATABASE_URL", ""),
+                auth_uid=os.environ.get(f"{env_prefix}_AUTH_UID", ""),
+                auth_provider_name=os.environ.get(f"{env_prefix}_AUTH_PROVIDER_NAME", ""),
+            )
+
+        need_stalwart = "jmap" in (side_a_backend, side_b_backend)
+        need_m365 = "graph" in (side_a_backend, side_b_backend)
+
+        stalwart_jmap_url = (
+            req("SYNC_STALWART_JMAP_URL") if need_stalwart
+            else os.environ.get("SYNC_STALWART_JMAP_URL", "")
+        )
+
+        def maybe_dav(prefix: str, when: bool) -> Optional[DavConfig]:
+            if not when:
+                return None
+            return DavConfig(
+                base_url=req(f"{prefix}_DAV_URL"),
+                username=req(f"{prefix}_DAV_USERNAME"),
+                password=req(f"{prefix}_DAV_PASSWORD"),
+            )
+
+        side_a_dav = maybe_dav(
+            "SYNC_SIDE_A", side_a_backend in {"carddav", "caldav"},
+        )
+        side_b_dav = maybe_dav(
+            "SYNC_SIDE_B", side_b_backend in {"carddav", "caldav"},
+        )
+
         return cls(
             sync_type=os.environ.get("SYNC_TYPE", "contacts"),
-            stalwart=ProviderConfig(
-                auth_database_url=req("SYNC_STALWART_AUTH_DATABASE_URL"),
-                auth_uid=req("SYNC_STALWART_AUTH_UID"),
-                auth_provider_name=req("SYNC_STALWART_AUTH_PROVIDER_NAME"),
-            ),
-            stalwart_jmap_url=req("SYNC_STALWART_JMAP_URL"),
+            side_a_backend=side_a_backend,
+            side_b_backend=side_b_backend,
+            stalwart=maybe_provider("SYNC_STALWART", need_stalwart),
+            stalwart_jmap_url=stalwart_jmap_url,
             stalwart_addressbook=os.environ.get("SYNC_STALWART_ADDRESSBOOK"),
             stalwart_calendar=os.environ.get("SYNC_STALWART_CALENDAR"),
-            m365=ProviderConfig(
-                auth_database_url=req("SYNC_M365_AUTH_DATABASE_URL"),
-                auth_uid=req("SYNC_M365_AUTH_UID"),
-                auth_provider_name=req("SYNC_M365_AUTH_PROVIDER_NAME"),
-            ),
+            m365=maybe_provider("SYNC_M365", need_m365),
             m365_addressbook=os.environ.get("SYNC_M365_ADDRESSBOOK"),
             m365_calendar=os.environ.get("SYNC_M365_CALENDAR"),
+            side_a_dav=side_a_dav,
+            side_b_dav=side_b_dav,
             state_database_url=os.environ.get(
                 "SYNC_STATE_DATABASE_URL", f"sqlite:///{DEFAULT_STATE_DB}"
             ),

--- a/src/groupware_sync/models.py
+++ b/src/groupware_sync/models.py
@@ -160,7 +160,21 @@ class SyncItem:
 
 @dataclass
 class SyncOp:
-    """An operation produced by tree comparison, executed later."""
+    """An operation produced by tree comparison, executed later.
+
+    `node_id` semantics differ by op_type — the executor relies on this
+    convention, so producers in tree.py must preserve it:
+
+    - CREATE_ITEM / CREATE_CONTAINER: source-side id (the side opposite of
+      target_side). The executor uses it to fetch the item from the source
+      provider before pushing to the target.
+    - DELETE_ITEM with target_side in {"a", "b"}: target-side id (the id
+      that will be passed to provider.delete_item). `paired_node_id` is
+      the other side's id, used only for cache cleanup.
+    - DELETE_ITEM with target_side="both", MERGE_ITEM, SKIP_SUBTREE: both
+      sides exist, so `node_id` is always the A-side id and
+      `paired_node_id` is the B-side id, regardless of target_side.
+    """
 
     op_type: OpType
     target_side: str  # "a", "b", or "both"

--- a/src/groupware_sync_calendar/cli.py
+++ b/src/groupware_sync_calendar/cli.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 
 import logging
 import sys
+from typing import Optional
 
 import typer
 
 from groupware_sync import auth as fw_auth
-from groupware_sync.config import Config
+from groupware_sync.config import CALENDAR_BACKENDS, Config
 from groupware_sync.engine import sync_trees
 from groupware_sync.models import ItemType
+from groupware_sync.provider import SyncProvider
 from groupware_sync.state.db import make_session_factory
 
 app = typer.Typer(
-    help="Two-way calendar sync between Stalwart and Microsoft 365",
+    help="Two-way calendar sync between supported backends "
+         "(JMAP / Graph / CalDAV)",
     no_args_is_help=True,
 )
 
@@ -39,6 +42,68 @@ def _stdin_isatty() -> bool:
     return sys.stdin.isatty()
 
 
+def _build_calendar_provider(cfg: Config, side: str) -> SyncProvider:
+    """Construct the calendar provider for a given side based on the
+    backend selector. Raises typer.Exit on auth or config errors."""
+    backend = cfg.side_a_backend if side == "a" else cfg.side_b_backend
+
+    if backend not in CALENDAR_BACKENDS:
+        typer.echo(
+            f"side {side}: unsupported calendar backend '{backend}' "
+            f"(expected one of {sorted(CALENDAR_BACKENDS)})", err=True,
+        )
+        raise typer.Exit(2)
+
+    if backend == "jmap":
+        from groupware_sync_calendar.adapters.jmap_adapter import JmapCalendarAdapter
+        try:
+            token = fw_auth.get_access_token(
+                cfg.stalwart.auth_database_url,
+                cfg.stalwart.auth_uid,
+                cfg.stalwart.auth_provider_name,
+            )
+        except ValueError as e:
+            typer.echo(f"stalwart auth error: {e}", err=True)
+            raise typer.Exit(2)
+        return JmapCalendarAdapter(
+            cfg.stalwart_jmap_url, token,
+            calendar_filter=cfg.stalwart_calendar,
+        )
+
+    if backend == "graph":
+        from groupware_sync_calendar.adapters.graph_adapter import GraphCalendarAdapter
+        try:
+            token = fw_auth.get_access_token(
+                cfg.m365.auth_database_url,
+                cfg.m365.auth_uid,
+                cfg.m365.auth_provider_name,
+            )
+        except Exception as e:
+            typer.echo(f"m365 auth error: {e}", err=True)
+            raise typer.Exit(2)
+        return GraphCalendarAdapter(
+            token, calendar_filter=cfg.m365_calendar,
+        )
+
+    # backend == "caldav"
+    dav = cfg.side_a_dav if side == "a" else cfg.side_b_dav
+    if dav is None:
+        typer.echo(
+            f"side {side}: caldav backend selected but "
+            f"SYNC_SIDE_{side.upper()}_DAV_* env vars are missing", err=True,
+        )
+        raise typer.Exit(2)
+    from groupware_sync_calendar.adapters.caldav_adapter import CalDavCalendarAdapter
+    # Reuse the side-specific calendar_filter env var (stalwart_calendar
+    # for side A, m365_calendar for side B) so existing operators don't
+    # learn a third name.
+    calendar_filter = cfg.stalwart_calendar if side == "a" else cfg.m365_calendar
+    return CalDavCalendarAdapter(
+        dav.base_url, dav.username, dav.password,
+        calendar_filter=calendar_filter,
+    )
+
+
 @app.command(name="sync")
 def sync_cmd(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging"),
@@ -47,6 +112,16 @@ def sync_cmd(
         False,
         "--non-interactive",
         help="Skip the interactive confirmation and execute immediately. Intended for cron and CI.",
+    ),
+    side_a_backend: Optional[str] = typer.Option(
+        None, "--side-a-backend",
+        help=f"Backend for side A. Overrides SYNC_SIDE_A_BACKEND. "
+             f"One of: {', '.join(sorted(CALENDAR_BACKENDS))}.",
+    ),
+    side_b_backend: Optional[str] = typer.Option(
+        None, "--side-b-backend",
+        help=f"Backend for side B. Overrides SYNC_SIDE_B_BACKEND. "
+             f"One of: {', '.join(sorted(CALENDAR_BACKENDS))}.",
     ),
 ) -> None:
     """Two-way calendar sync using the tree-based framework engine."""
@@ -62,8 +137,13 @@ def sync_cmd(
         )
         raise typer.Exit(2)
 
-    from groupware_sync_calendar.adapters.graph_adapter import GraphCalendarAdapter
-    from groupware_sync_calendar.adapters.jmap_adapter import JmapCalendarAdapter
+    if side_a_backend is not None:
+        import os
+        os.environ["SYNC_SIDE_A_BACKEND"] = side_a_backend
+    if side_b_backend is not None:
+        import os
+        os.environ["SYNC_SIDE_B_BACKEND"] = side_b_backend
+
     from groupware_sync_calendar.specs import CALENDAR_EVENT_SPEC
 
     try:
@@ -72,24 +152,8 @@ def sync_cmd(
         typer.echo(f"config error: {e}", err=True)
         raise typer.Exit(2)
 
-    try:
-        stalwart_token = fw_auth.get_access_token(
-            cfg.stalwart.auth_database_url, cfg.stalwart.auth_uid, cfg.stalwart.auth_provider_name,
-        )
-    except ValueError as e:
-        typer.echo(f"stalwart auth error: {e}", err=True)
-        raise typer.Exit(2)
-
-    try:
-        m365_token = fw_auth.get_access_token(
-            cfg.m365.auth_database_url, cfg.m365.auth_uid, cfg.m365.auth_provider_name,
-        )
-    except Exception as e:
-        typer.echo(f"m365 auth error: {e}", err=True)
-        raise typer.Exit(2)
-
-    jmap = JmapCalendarAdapter(cfg.stalwart_jmap_url, stalwart_token, calendar_filter=cfg.stalwart_calendar)
-    graph = GraphCalendarAdapter(m365_token, calendar_filter=cfg.m365_calendar)
+    provider_a = _build_calendar_provider(cfg, "a")
+    provider_b = _build_calendar_provider(cfg, "b")
     sf = make_session_factory(cfg.state_database_url)
 
     # Choose engine inputs. --dry-run wins silently over --non-interactive.
@@ -107,7 +171,7 @@ def sync_cmd(
     try:
         with sf() as session:
             summary = sync_trees(
-                jmap, graph, ItemType.CALENDAR_EVENT, CALENDAR_EVENT_SPEC, session,
+                provider_a, provider_b, ItemType.CALENDAR_EVENT, CALENDAR_EVENT_SPEC, session,
                 dry_run=dry_run, confirm=confirm,
             )
     except Exception as e:
@@ -115,8 +179,10 @@ def sync_cmd(
         typer.echo(f"sync failed: {e}", err=True)
         raise typer.Exit(2)
     finally:
-        jmap.close()
-        graph.close()
+        for p in (provider_a, provider_b):
+            close = getattr(p, "close", None)
+            if callable(close):
+                close()
 
     if summary.aborted:
         typer.echo("sync aborted by user — no changes made")

--- a/src/groupware_sync_calendar/cli.py
+++ b/src/groupware_sync_calendar/cli.py
@@ -93,7 +93,19 @@ def _build_calendar_provider(cfg: Config, side: str) -> SyncProvider:
             f"SYNC_SIDE_{side.upper()}_DAV_* env vars are missing", err=True,
         )
         raise typer.Exit(2)
-    from groupware_sync_calendar.adapters.caldav_adapter import CalDavCalendarAdapter
+    try:
+        from groupware_sync_calendar.adapters.caldav_adapter import (
+            CalDavCalendarAdapter,
+        )
+    except ImportError as e:
+        # CalDAV adapter pulls in vobject for iCalendar parsing. It's not
+        # required by the default jmap/graph topology, so translate the
+        # import error into a clear exit instead of letting it crash.
+        typer.echo(
+            f"side {side}: caldav backend requires the 'vobject' package "
+            f"(pip install vobject): {e}", err=True,
+        )
+        raise typer.Exit(2)
     # Reuse the side-specific calendar_filter env var (stalwart_calendar
     # for side A, m365_calendar for side B) so existing operators don't
     # learn a third name.
@@ -228,11 +240,27 @@ def repair_jmap_alerts_cmd(
         typer.echo(f"config error: {e}", err=True)
         raise typer.Exit(2)
 
+    # `repair-jmap-alerts` is JMAP-specific by design and runs against
+    # Stalwart regardless of the side selectors, but the per-side backend
+    # work made `cfg.stalwart.*` optional — when neither side selects
+    # `jmap`, those fields are empty strings and downstream auth code
+    # raises a SQLAlchemy URL parse error rather than a clean ValueError.
+    # Validate up-front so the operator sees the missing-config message.
+    if not (cfg.stalwart.auth_database_url and cfg.stalwart.auth_uid
+            and cfg.stalwart.auth_provider_name and cfg.stalwart_jmap_url):
+        typer.echo(
+            "repair-jmap-alerts requires Stalwart config: set "
+            "SYNC_STALWART_JMAP_URL, SYNC_STALWART_AUTH_DATABASE_URL, "
+            "SYNC_STALWART_AUTH_UID, SYNC_STALWART_AUTH_PROVIDER_NAME",
+            err=True,
+        )
+        raise typer.Exit(2)
+
     try:
         stalwart_token = fw_auth.get_access_token(
             cfg.stalwart.auth_database_url, cfg.stalwart.auth_uid, cfg.stalwart.auth_provider_name,
         )
-    except ValueError as e:
+    except Exception as e:
         typer.echo(f"stalwart auth error: {e}", err=True)
         raise typer.Exit(2)
 

--- a/src/groupware_sync_contacts/adapters/graph_adapter.py
+++ b/src/groupware_sync_contacts/adapters/graph_adapter.py
@@ -207,7 +207,11 @@ class GraphContactAdapter(SyncProvider):
                     continue
                 r.raise_for_status()
                 item = _graph_to_sync_item(r.json())
-                # Fetch photo separately (stored outside the contact JSON)
+                # Fetch photo separately (stored outside the contact JSON).
+                # 404 means "no photo" and is the common case — leave the
+                # fields unset and move on. Other transport/parse failures
+                # are real and must surface in the logs so they're not
+                # invisible.
                 try:
                     photo_resp = self._request("GET", f"/me/contacts/{cid}/photo/$value")
                     if photo_resp.status_code == 200:
@@ -215,8 +219,16 @@ class GraphContactAdapter(SyncProvider):
                         item.fields["photo"] = base64.b64encode(photo_resp.content).decode("ascii")
                         content_type = photo_resp.headers.get("content-type", "image/jpeg")
                         item.fields["photo_type"] = content_type
+                    elif photo_resp.status_code != 404:
+                        log.warning(
+                            "graph contact %s photo fetch returned %s",
+                            cid, photo_resp.status_code,
+                        )
                 except Exception:
-                    pass  # no photo or error, skip silently
+                    log.warning(
+                        "graph contact %s photo fetch failed", cid,
+                        exc_info=True,
+                    )
                 items.append(item)
             except httpx.HTTPStatusError as e:
                 log.error("graph get contact %s failed: %s", cid, e)

--- a/src/groupware_sync_contacts/cli.py
+++ b/src/groupware_sync_contacts/cli.py
@@ -7,24 +7,27 @@ from __future__ import annotations
 
 import logging
 import sys
+from typing import Optional
 
 import typer
 
 from groupware_sync import auth as fw_auth
-from groupware_sync.config import Config
+from groupware_sync.config import CONTACT_BACKENDS, Config
 from groupware_sync.engine import sync_trees
 from groupware_sync.models import ItemType
+from groupware_sync.provider import SyncProvider
 from groupware_sync.state.db import make_session_factory
 
 app = typer.Typer(
-    help="Two-way contacts sync between Stalwart and Microsoft 365",
+    help="Two-way contacts sync between supported backends "
+         "(JMAP / Graph / CardDAV)",
     no_args_is_help=True,
 )
 
 
 @app.callback()
 def _callback() -> None:
-    """Two-way contacts sync between Stalwart and Microsoft 365."""
+    """Two-way contacts sync between supported backends."""
 
 
 def _setup_logging(verbose: bool) -> None:
@@ -46,6 +49,62 @@ def _stdin_isatty() -> bool:
     return sys.stdin.isatty()
 
 
+def _build_contact_provider(cfg: Config, side: str) -> SyncProvider:
+    """Construct the contact provider for a given side based on the
+    backend selector. Raises typer.Exit on auth or config errors so the
+    CLI can route them through the existing error-reporting pattern."""
+    backend = cfg.side_a_backend if side == "a" else cfg.side_b_backend
+
+    if backend not in CONTACT_BACKENDS:
+        typer.echo(
+            f"side {side}: unsupported contacts backend '{backend}' "
+            f"(expected one of {sorted(CONTACT_BACKENDS)})", err=True,
+        )
+        raise typer.Exit(2)
+
+    if backend == "jmap":
+        from groupware_sync_contacts.adapters.jmap_adapter import JmapContactAdapter
+        try:
+            token = fw_auth.get_access_token(
+                cfg.stalwart.auth_database_url,
+                cfg.stalwart.auth_uid,
+                cfg.stalwart.auth_provider_name,
+            )
+        except ValueError as e:
+            typer.echo(f"stalwart auth error: {e}", err=True)
+            raise typer.Exit(2)
+        return JmapContactAdapter(
+            cfg.stalwart_jmap_url, token,
+            addressbook_filter=cfg.stalwart_addressbook,
+        )
+
+    if backend == "graph":
+        from groupware_sync_contacts.adapters.graph_adapter import GraphContactAdapter
+        try:
+            token = fw_auth.get_access_token(
+                cfg.m365.auth_database_url,
+                cfg.m365.auth_uid,
+                cfg.m365.auth_provider_name,
+            )
+        except Exception as e:
+            typer.echo(f"m365 auth error: {e}", err=True)
+            raise typer.Exit(2)
+        return GraphContactAdapter(
+            token, addressbook_filter=cfg.m365_addressbook,
+        )
+
+    # backend == "carddav"
+    dav = cfg.side_a_dav if side == "a" else cfg.side_b_dav
+    if dav is None:
+        typer.echo(
+            f"side {side}: carddav backend selected but "
+            f"SYNC_SIDE_{side.upper()}_DAV_* env vars are missing", err=True,
+        )
+        raise typer.Exit(2)
+    from groupware_sync_contacts.adapters.carddav_adapter import CardDavContactAdapter
+    return CardDavContactAdapter(dav.base_url, dav.username, dav.password)
+
+
 @app.command(name="sync")
 def sync_cmd(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable debug logging"),
@@ -54,6 +113,16 @@ def sync_cmd(
         False,
         "--non-interactive",
         help="Skip the interactive confirmation and execute immediately. Intended for cron and CI.",
+    ),
+    side_a_backend: Optional[str] = typer.Option(
+        None, "--side-a-backend",
+        help=f"Backend for side A. Overrides SYNC_SIDE_A_BACKEND. "
+             f"One of: {', '.join(sorted(CONTACT_BACKENDS))}.",
+    ),
+    side_b_backend: Optional[str] = typer.Option(
+        None, "--side-b-backend",
+        help=f"Backend for side B. Overrides SYNC_SIDE_B_BACKEND. "
+             f"One of: {', '.join(sorted(CONTACT_BACKENDS))}.",
     ),
 ) -> None:
     """Two-way contacts sync using the tree-based framework engine."""
@@ -69,8 +138,15 @@ def sync_cmd(
         )
         raise typer.Exit(2)
 
-    from groupware_sync_contacts.adapters.graph_adapter import GraphContactAdapter
-    from groupware_sync_contacts.adapters.jmap_adapter import JmapContactAdapter
+    # CLI flags override env-derived selectors before we reload the rest
+    # of the config (which validates per-backend env vars).
+    if side_a_backend is not None:
+        import os
+        os.environ["SYNC_SIDE_A_BACKEND"] = side_a_backend
+    if side_b_backend is not None:
+        import os
+        os.environ["SYNC_SIDE_B_BACKEND"] = side_b_backend
+
     from groupware_sync_contacts.specs import CONTACT_SPEC
 
     try:
@@ -79,28 +155,8 @@ def sync_cmd(
         typer.echo(f"config error: {e}", err=True)
         raise typer.Exit(2)
 
-    try:
-        stalwart_token = fw_auth.get_access_token(
-            cfg.stalwart.auth_database_url,
-            cfg.stalwart.auth_uid,
-            cfg.stalwart.auth_provider_name,
-        )
-    except ValueError as e:
-        typer.echo(f"stalwart auth error: {e}", err=True)
-        raise typer.Exit(2)
-
-    try:
-        m365_token = fw_auth.get_access_token(
-            cfg.m365.auth_database_url,
-            cfg.m365.auth_uid,
-            cfg.m365.auth_provider_name,
-        )
-    except Exception as e:
-        typer.echo(f"m365 auth error: {e}", err=True)
-        raise typer.Exit(2)
-
-    jmap = JmapContactAdapter(cfg.stalwart_jmap_url, stalwart_token, addressbook_filter=cfg.stalwart_addressbook)
-    graph = GraphContactAdapter(m365_token, addressbook_filter=cfg.m365_addressbook)
+    provider_a = _build_contact_provider(cfg, "a")
+    provider_b = _build_contact_provider(cfg, "b")
     sf = make_session_factory(cfg.state_database_url)
 
     # Choose engine inputs. --dry-run wins silently over --non-interactive.
@@ -118,7 +174,7 @@ def sync_cmd(
     try:
         with sf() as session:
             summary = sync_trees(
-                jmap, graph, ItemType.CONTACT, CONTACT_SPEC, session,
+                provider_a, provider_b, ItemType.CONTACT, CONTACT_SPEC, session,
                 dry_run=dry_run, confirm=confirm,
             )
     except Exception as e:
@@ -126,8 +182,12 @@ def sync_cmd(
         typer.echo(f"sync failed: {e}", err=True)
         raise typer.Exit(2)
     finally:
-        jmap.close()
-        graph.close()
+        # Adapters expose .close() if they hold an httpx client; tolerate
+        # absence so future protocol-only adapters needn't bother.
+        for p in (provider_a, provider_b):
+            close = getattr(p, "close", None)
+            if callable(close):
+                close()
 
     if summary.aborted:
         typer.echo("sync aborted by user — no changes made")

--- a/src/groupware_sync_contacts/cli.py
+++ b/src/groupware_sync_contacts/cli.py
@@ -101,7 +101,19 @@ def _build_contact_provider(cfg: Config, side: str) -> SyncProvider:
             f"SYNC_SIDE_{side.upper()}_DAV_* env vars are missing", err=True,
         )
         raise typer.Exit(2)
-    from groupware_sync_contacts.adapters.carddav_adapter import CardDavContactAdapter
+    try:
+        from groupware_sync_contacts.adapters.carddav_adapter import (
+            CardDavContactAdapter,
+        )
+    except ImportError as e:
+        # CardDAV adapter pulls in vobject for vCard parsing. It's not
+        # required by the default jmap/graph topology, so it isn't a hard
+        # dependency — translate the import error into a clear exit.
+        typer.echo(
+            f"side {side}: carddav backend requires the 'vobject' package "
+            f"(pip install vobject): {e}", err=True,
+        )
+        raise typer.Exit(2)
     return CardDavContactAdapter(dav.base_url, dav.username, dav.password)
 
 

--- a/tests/test_cli_backend_dispatch.py
+++ b/tests/test_cli_backend_dispatch.py
@@ -1,0 +1,174 @@
+"""Issue #20: CLI/config wiring for CardDAV and CalDAV.
+
+Pins the per-side backend dispatch in the contacts and calendar CLIs:
+* default selectors still build the JMAP/Graph pair (back-compat),
+* `carddav`/`caldav` selectors build the DAV adapter from
+  ``cfg.side_X_dav``,
+* missing DAV credentials exit cleanly,
+* unknown backend names exit cleanly.
+
+These tests stub adapter ``__init__`` so the dispatch logic is exercised
+without touching the network or instantiating any real client.
+"""
+from __future__ import annotations
+
+import typer
+import pytest
+
+from groupware_sync.config import Config, DavConfig, ProviderConfig
+from groupware_sync_calendar.cli import _build_calendar_provider
+from groupware_sync_contacts.cli import _build_contact_provider
+
+
+def _base_cfg(**overrides) -> Config:
+    prov = ProviderConfig(
+        auth_database_url="x", auth_uid="x", auth_provider_name="x",
+    )
+    base = dict(
+        sync_type="contacts",
+        side_a_backend="jmap",
+        side_b_backend="graph",
+        stalwart=prov,
+        stalwart_jmap_url="https://stalwart.invalid",
+        stalwart_addressbook=None,
+        stalwart_calendar=None,
+        m365=prov,
+        m365_addressbook=None,
+        m365_calendar=None,
+        side_a_dav=None,
+        side_b_dav=None,
+        state_database_url="sqlite:///:memory:",
+    )
+    base.update(overrides)
+    return Config(**base)
+
+
+@pytest.fixture(autouse=True)
+def _stub_adapters(monkeypatch):
+    """Replace adapter __init__/close with no-ops so dispatch can be
+    exercised without httpx clients or real OAuth tokens."""
+    targets = [
+        "groupware_sync_contacts.adapters.jmap_adapter.JmapContactAdapter",
+        "groupware_sync_contacts.adapters.graph_adapter.GraphContactAdapter",
+        "groupware_sync_contacts.adapters.carddav_adapter.CardDavContactAdapter",
+        "groupware_sync_calendar.adapters.jmap_adapter.JmapCalendarAdapter",
+        "groupware_sync_calendar.adapters.graph_adapter.GraphCalendarAdapter",
+        "groupware_sync_calendar.adapters.caldav_adapter.CalDavCalendarAdapter",
+    ]
+    for path in targets:
+        try:
+            monkeypatch.setattr(f"{path}.__init__", lambda self, *a, **kw: None)
+            monkeypatch.setattr(f"{path}.close", lambda self: None, raising=False)
+        except (ImportError, AttributeError):
+            # vobject-dependent adapters may be unavailable in some envs;
+            # tests that need those skip explicitly below.
+            pass
+
+    # Auth lookups must succeed regardless of the (fake) URLs in cfg.
+    monkeypatch.setattr(
+        "groupware_sync_contacts.cli.fw_auth.get_access_token",
+        lambda *a, **kw: "token", raising=False,
+    )
+    monkeypatch.setattr(
+        "groupware_sync_calendar.cli.fw_auth.get_access_token",
+        lambda *a, **kw: "token", raising=False,
+    )
+
+
+# ---------- contacts ----------
+
+
+def test_contacts_default_dispatch_builds_jmap_and_graph():
+    from groupware_sync_contacts.adapters.graph_adapter import GraphContactAdapter
+    from groupware_sync_contacts.adapters.jmap_adapter import JmapContactAdapter
+
+    cfg = _base_cfg()
+    a = _build_contact_provider(cfg, "a")
+    b = _build_contact_provider(cfg, "b")
+    assert isinstance(a, JmapContactAdapter)
+    assert isinstance(b, GraphContactAdapter)
+
+
+def test_contacts_carddav_on_side_a_uses_side_a_dav():
+    try:
+        from groupware_sync_contacts.adapters.carddav_adapter import (
+            CardDavContactAdapter,
+        )
+    except ModuleNotFoundError:
+        pytest.skip("vobject not installed")
+
+    cfg = _base_cfg(
+        side_a_backend="carddav",
+        side_a_dav=DavConfig(
+            base_url="https://dav.invalid", username="u", password="p",
+        ),
+    )
+    a = _build_contact_provider(cfg, "a")
+    assert isinstance(a, CardDavContactAdapter)
+
+
+def test_contacts_carddav_without_credentials_exits_2():
+    cfg = _base_cfg(side_a_backend="carddav", side_a_dav=None)
+    with pytest.raises(typer.Exit) as exc_info:
+        _build_contact_provider(cfg, "a")
+    assert exc_info.value.exit_code == 2
+
+
+def test_contacts_unknown_backend_exits_2():
+    cfg = _base_cfg(side_a_backend="bogus")
+    with pytest.raises(typer.Exit) as exc_info:
+        _build_contact_provider(cfg, "a")
+    assert exc_info.value.exit_code == 2
+
+
+def test_contacts_caldav_is_not_a_contact_backend():
+    cfg = _base_cfg(side_a_backend="caldav")
+    with pytest.raises(typer.Exit) as exc_info:
+        _build_contact_provider(cfg, "a")
+    assert exc_info.value.exit_code == 2
+
+
+# ---------- calendar ----------
+
+
+def test_calendar_default_dispatch_builds_jmap_and_graph():
+    from groupware_sync_calendar.adapters.graph_adapter import GraphCalendarAdapter
+    from groupware_sync_calendar.adapters.jmap_adapter import JmapCalendarAdapter
+
+    cfg = _base_cfg()
+    a = _build_calendar_provider(cfg, "a")
+    b = _build_calendar_provider(cfg, "b")
+    assert isinstance(a, JmapCalendarAdapter)
+    assert isinstance(b, GraphCalendarAdapter)
+
+
+def test_calendar_caldav_on_side_b_uses_side_b_dav():
+    try:
+        from groupware_sync_calendar.adapters.caldav_adapter import (
+            CalDavCalendarAdapter,
+        )
+    except ModuleNotFoundError:
+        pytest.skip("vobject not installed")
+
+    cfg = _base_cfg(
+        side_b_backend="caldav",
+        side_b_dav=DavConfig(
+            base_url="https://dav.invalid", username="u", password="p",
+        ),
+    )
+    b = _build_calendar_provider(cfg, "b")
+    assert isinstance(b, CalDavCalendarAdapter)
+
+
+def test_calendar_caldav_without_credentials_exits_2():
+    cfg = _base_cfg(side_b_backend="caldav", side_b_dav=None)
+    with pytest.raises(typer.Exit) as exc_info:
+        _build_calendar_provider(cfg, "b")
+    assert exc_info.value.exit_code == 2
+
+
+def test_calendar_carddav_is_not_a_calendar_backend():
+    cfg = _base_cfg(side_a_backend="carddav")
+    with pytest.raises(typer.Exit) as exc_info:
+        _build_calendar_provider(cfg, "a")
+    assert exc_info.value.exit_code == 2

--- a/tests/test_cli_backend_dispatch.py
+++ b/tests/test_cli_backend_dispatch.py
@@ -12,8 +12,8 @@ without touching the network or instantiating any real client.
 """
 from __future__ import annotations
 
-import typer
 import pytest
+import typer
 
 from groupware_sync.config import Config, DavConfig, ProviderConfig
 from groupware_sync_calendar.cli import _build_calendar_provider

--- a/tests/test_cli_calendar.py
+++ b/tests/test_cli_calendar.py
@@ -21,6 +21,8 @@ def _fake_cfg() -> Config:
     prov = ProviderConfig(auth_database_url="x", auth_uid="x", auth_provider_name="x")
     return Config(
         sync_type="calendar",
+        side_a_backend="jmap",
+        side_b_backend="graph",
         stalwart=prov,
         stalwart_jmap_url="https://stalwart.invalid",
         stalwart_addressbook=None,
@@ -28,6 +30,8 @@ def _fake_cfg() -> Config:
         m365=prov,
         m365_addressbook=None,
         m365_calendar=None,
+        side_a_dav=None,
+        side_b_dav=None,
         state_database_url="sqlite:///:memory:",
     )
 

--- a/tests/test_cli_contacts.py
+++ b/tests/test_cli_contacts.py
@@ -21,6 +21,8 @@ def _fake_cfg() -> Config:
     prov = ProviderConfig(auth_database_url="x", auth_uid="x", auth_provider_name="x")
     return Config(
         sync_type="contacts",
+        side_a_backend="jmap",
+        side_b_backend="graph",
         stalwart=prov,
         stalwart_jmap_url="https://stalwart.invalid",
         stalwart_addressbook=None,
@@ -28,6 +30,8 @@ def _fake_cfg() -> Config:
         m365=prov,
         m365_addressbook=None,
         m365_calendar=None,
+        side_a_dav=None,
+        side_b_dav=None,
         state_database_url="sqlite:///:memory:",
     )
 

--- a/tests/test_config_backends.py
+++ b/tests/test_config_backends.py
@@ -1,0 +1,129 @@
+"""Issue #20: Config.from_env() must accept per-side backend selectors.
+
+Pins the env-var contract introduced for CardDAV/CalDAV support:
+* defaults preserve the original Stalwart-JMAP / M365-Graph topology
+* selecting `carddav`/`caldav` for a side requires its own DAV credentials
+* selecting a non-default backend on either side relaxes the OAuth
+  requirements for the backend that is no longer in use
+"""
+from __future__ import annotations
+
+import pytest
+
+from groupware_sync.config import Config
+
+
+def _set(monkeypatch, **env):
+    """Set or unset env vars (None deletes)."""
+    for k, v in env.items():
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, v)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    # Clear every variable the Config reads so each test starts fresh.
+    for var in [
+        "SYNC_TYPE",
+        "SYNC_SIDE_A_BACKEND", "SYNC_SIDE_B_BACKEND",
+        "SYNC_STALWART_AUTH_DATABASE_URL", "SYNC_STALWART_AUTH_UID",
+        "SYNC_STALWART_AUTH_PROVIDER_NAME", "SYNC_STALWART_JMAP_URL",
+        "SYNC_STALWART_ADDRESSBOOK", "SYNC_STALWART_CALENDAR",
+        "SYNC_M365_AUTH_DATABASE_URL", "SYNC_M365_AUTH_UID",
+        "SYNC_M365_AUTH_PROVIDER_NAME",
+        "SYNC_M365_ADDRESSBOOK", "SYNC_M365_CALENDAR",
+        "SYNC_SIDE_A_DAV_URL", "SYNC_SIDE_A_DAV_USERNAME",
+        "SYNC_SIDE_A_DAV_PASSWORD",
+        "SYNC_SIDE_B_DAV_URL", "SYNC_SIDE_B_DAV_USERNAME",
+        "SYNC_SIDE_B_DAV_PASSWORD",
+        "SYNC_STATE_DATABASE_URL",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_default_topology_preserves_legacy_env_vars(monkeypatch):
+    _set(
+        monkeypatch,
+        SYNC_STALWART_AUTH_DATABASE_URL="sqlite:///s.db",
+        SYNC_STALWART_AUTH_UID="alice",
+        SYNC_STALWART_AUTH_PROVIDER_NAME="stalwart",
+        SYNC_STALWART_JMAP_URL="https://stalwart.invalid",
+        SYNC_M365_AUTH_DATABASE_URL="sqlite:///m.db",
+        SYNC_M365_AUTH_UID="alice@example.com",
+        SYNC_M365_AUTH_PROVIDER_NAME="m365",
+    )
+    cfg = Config.from_env()
+    assert cfg.side_a_backend == "jmap"
+    assert cfg.side_b_backend == "graph"
+    assert cfg.side_a_dav is None
+    assert cfg.side_b_dav is None
+    assert cfg.stalwart.auth_uid == "alice"
+    assert cfg.m365.auth_uid == "alice@example.com"
+
+
+def test_carddav_on_side_a_loads_dav_credentials(monkeypatch):
+    _set(
+        monkeypatch,
+        SYNC_SIDE_A_BACKEND="carddav",
+        # side B is still graph in this scenario, so M365 OAuth required.
+        SYNC_M365_AUTH_DATABASE_URL="sqlite:///m.db",
+        SYNC_M365_AUTH_UID="alice@example.com",
+        SYNC_M365_AUTH_PROVIDER_NAME="m365",
+        SYNC_SIDE_A_DAV_URL="https://radicale.invalid",
+        SYNC_SIDE_A_DAV_USERNAME="alice",
+        SYNC_SIDE_A_DAV_PASSWORD="hunter2",
+    )
+    cfg = Config.from_env()
+    assert cfg.side_a_backend == "carddav"
+    assert cfg.side_a_dav is not None
+    assert cfg.side_a_dav.base_url == "https://radicale.invalid"
+    assert cfg.side_a_dav.username == "alice"
+    assert cfg.side_a_dav.password == "hunter2"
+    # JMAP no longer needed → its OAuth fields are tolerated as missing.
+    assert cfg.stalwart.auth_uid == ""
+
+
+def test_carddav_without_dav_url_raises(monkeypatch):
+    _set(
+        monkeypatch,
+        SYNC_SIDE_A_BACKEND="carddav",
+        SYNC_M365_AUTH_DATABASE_URL="sqlite:///m.db",
+        SYNC_M365_AUTH_UID="alice@example.com",
+        SYNC_M365_AUTH_PROVIDER_NAME="m365",
+        # SYNC_SIDE_A_DAV_* deliberately unset
+    )
+    with pytest.raises(ValueError, match="SYNC_SIDE_A_DAV_URL"):
+        Config.from_env()
+
+
+def test_carddav_only_topology_drops_oauth_requirement(monkeypatch):
+    """Both sides DAV → neither Stalwart nor M365 OAuth env vars needed."""
+    _set(
+        monkeypatch,
+        SYNC_SIDE_A_BACKEND="carddav",
+        SYNC_SIDE_B_BACKEND="carddav",
+        SYNC_SIDE_A_DAV_URL="https://a.invalid",
+        SYNC_SIDE_A_DAV_USERNAME="alice",
+        SYNC_SIDE_A_DAV_PASSWORD="pwa",
+        SYNC_SIDE_B_DAV_URL="https://b.invalid",
+        SYNC_SIDE_B_DAV_USERNAME="bob",
+        SYNC_SIDE_B_DAV_PASSWORD="pwb",
+    )
+    cfg = Config.from_env()
+    assert cfg.side_a_dav is not None and cfg.side_b_dav is not None
+    assert cfg.stalwart_jmap_url == ""  # not required when no JMAP side
+
+
+def test_default_still_requires_stalwart_oauth(monkeypatch):
+    """Back-compat guard: dropping the default Stalwart env vars without
+    selecting a different backend still surfaces a clear error."""
+    _set(
+        monkeypatch,
+        SYNC_M365_AUTH_DATABASE_URL="sqlite:///m.db",
+        SYNC_M365_AUTH_UID="alice@example.com",
+        SYNC_M365_AUTH_PROVIDER_NAME="m365",
+    )
+    with pytest.raises(ValueError, match="SYNC_STALWART"):
+        Config.from_env()

--- a/tests/test_engine_regression.py
+++ b/tests/test_engine_regression.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import pytest
 
 from groupware_sync.engine import _execute_delete, _merge_one, _save_tree_cursors
-from groupware_sync.tree import compare_trees
 from groupware_sync.models import (
     FieldDef,
     ItemType,
@@ -34,6 +33,7 @@ from groupware_sync.provider import (
 )
 from groupware_sync.state import ops
 from groupware_sync.state.db import make_session_factory
+from groupware_sync.tree import compare_trees
 
 
 @pytest.fixture

--- a/tests/test_engine_regression.py
+++ b/tests/test_engine_regression.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 
 import pytest
 
-from groupware_sync.engine import _merge_one, _save_tree_cursors
+from groupware_sync.engine import _execute_delete, _merge_one, _save_tree_cursors
+from groupware_sync.tree import compare_trees
 from groupware_sync.models import (
     FieldDef,
     ItemType,
@@ -145,6 +146,7 @@ class _RecordingProvider(SyncProvider):
         self.notification_policy = _policy()
         self._raise = raise_on_update
         self.update_calls: list[tuple[str, SyncItem]] = []
+        self.delete_calls: list[tuple[str, str]] = []
 
     @property
     def name(self) -> str:
@@ -172,6 +174,7 @@ class _RecordingProvider(SyncProvider):
         return f"fp-after-update-{self._name}"
 
     def delete_item(self, container_id, item_id):  # noqa: ANN001
+        self.delete_calls.append((container_id, item_id))
         return None
 
 
@@ -306,3 +309,113 @@ def test_merge_success_persists_fingerprints_and_snapshot(session):
 
     assert summary.errors == 0
     assert summary.updated == 1
+
+
+# ---------------------------------------------------------------------------
+# DELETE_ITEM target-id convention (audit MEDIUM #6 / issue #21)
+# ---------------------------------------------------------------------------
+#
+# The auditor was unsure whether `compare_trees` populates `op.node_id` with
+# the target-side id or the source-side id for DELETE_ITEM. The convention
+# (now documented on `SyncOp`) is: for DELETE_ITEM with target_side in
+# {"a","b"}, `node_id` is the target-side id and `paired_node_id` is the
+# other side's id. These tests pin that contract end-to-end so a future
+# refactor of either side fails loudly instead of silently deleting the
+# wrong item.
+
+
+def _build_leaf_tree(container_id: str, container_name: str,
+                     leaf_id: str | None,
+                     identity_key: str = "shared-ik") -> SyncNode:
+    """Build a tree with one container, optionally containing one leaf.
+
+    leaf_id is the side-specific id; identity_key defaults to a shared value
+    so first-sync identity pairing produces an ItemMapping that subsequent
+    syncs can resolve against (matching what real adapters do — e.g., two
+    sides agree on an email but each has its own opaque server id)."""
+    leaves = []
+    if leaf_id is not None:
+        leaves.append(
+            SyncNode(
+                leaf_id, leaf_id, NodeType.LEAF,
+                fingerprint=f"fp-{leaf_id}",
+                identity_key=identity_key,
+                item_type=ItemType.CONTACT,
+            )
+        )
+    container = SyncNode(
+        container_id, container_name, NodeType.CONTAINER, children=leaves,
+    )
+    root = SyncNode("root", "root", NodeType.CONTAINER, children=[container])
+    root.compute_merkle()
+    return root
+
+
+def test_delete_item_target_a_passes_a_side_id(session):
+    """B removed its copy → DELETE_ITEM(target=a) must carry A's id, not B's.
+    Asserted at both the op level and at the executor level."""
+    # First sync: both sides present, establish mapping.
+    tree_a = _build_leaf_tree("container-A", "Contacts", "a-id-1")
+    tree_b = _build_leaf_tree("container-B", "Contacts", "b-id-1")
+    compare_trees(tree_a, tree_b, "prov_a", "prov_b", ItemType.CONTACT, session)
+    session.commit()
+
+    # Second sync: B removed its copy. Mapping still says a-id-1 ↔ b-id-1.
+    tree_a2 = _build_leaf_tree("container-A", "Contacts", "a-id-1")
+    tree_b2 = _build_leaf_tree("container-B", "Contacts", None)
+    ops_list, _ = compare_trees(
+        tree_a2, tree_b2, "prov_a", "prov_b", ItemType.CONTACT, session,
+    )
+
+    deletes = [op for op in ops_list if op.op_type == OpType.DELETE_ITEM]
+    assert len(deletes) == 1
+    op = deletes[0]
+    assert op.target_side == "a"
+    # node_id is the side being deleted FROM (A here).
+    assert op.node_id == "a-id-1"
+    assert op.paired_node_id == "b-id-1"
+
+    # Executor must pass A's id to provider_a.delete_item, not B's.
+    provider_a = _RecordingProvider("a")
+    provider_b = _RecordingProvider("b")
+    summary = SyncSummary()
+    _execute_delete(op, provider_a, provider_b, session, summary)
+
+    assert provider_a.delete_calls == [("container-A", "a-id-1")]
+    assert provider_b.delete_calls == []
+    assert summary.deleted == 1
+    assert summary.errors == 0
+
+
+def test_delete_item_target_b_passes_b_side_id(session):
+    """A removed its copy → DELETE_ITEM(target=b) must carry B's id, not A's.
+    This is the auditor's original concern: that `node_id` might leak the
+    A-side leaf id even when target_side="b"."""
+    tree_a = _build_leaf_tree("container-A", "Contacts", "a-id-1")
+    tree_b = _build_leaf_tree("container-B", "Contacts", "b-id-1")
+    compare_trees(tree_a, tree_b, "prov_a", "prov_b", ItemType.CONTACT, session)
+    session.commit()
+
+    # A removed its copy.
+    tree_a2 = _build_leaf_tree("container-A", "Contacts", None)
+    tree_b2 = _build_leaf_tree("container-B", "Contacts", "b-id-1")
+    ops_list, _ = compare_trees(
+        tree_a2, tree_b2, "prov_a", "prov_b", ItemType.CONTACT, session,
+    )
+
+    deletes = [op for op in ops_list if op.op_type == OpType.DELETE_ITEM]
+    assert len(deletes) == 1
+    op = deletes[0]
+    assert op.target_side == "b"
+    assert op.node_id == "b-id-1"
+    assert op.paired_node_id == "a-id-1"
+
+    provider_a = _RecordingProvider("a")
+    provider_b = _RecordingProvider("b")
+    summary = SyncSummary()
+    _execute_delete(op, provider_a, provider_b, session, summary)
+
+    assert provider_b.delete_calls == [("container-B", "b-id-1")]
+    assert provider_a.delete_calls == []
+    assert summary.deleted == 1
+    assert summary.errors == 0

--- a/tests/test_graph_contact_photo_logging.py
+++ b/tests/test_graph_contact_photo_logging.py
@@ -1,0 +1,126 @@
+"""Photo fetch errors in GraphContactAdapter.get_items must surface in logs.
+
+Audit issue #23: the previous code swallowed every photo-fetch exception
+silently, which meant transport errors, auth failures, and programming
+bugs in the photo path were invisible in production.
+
+Contract pinned here:
+* HTTP 200 → photo fields populated (control case).
+* HTTP 404 → no log line; "no photo" is the common case.
+* Other HTTP status → WARNING with the status code.
+* Transport / parse exception → WARNING with traceback (exc_info).
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from groupware_sync_contacts.adapters.graph_adapter import (
+    GRAPH_BASE,
+    GraphContactAdapter,
+)
+
+
+def _adapter_with_handler(handler) -> GraphContactAdapter:
+    a = GraphContactAdapter("token")
+    a._client = httpx.Client(
+        base_url=GRAPH_BASE,
+        headers={"Authorization": "Bearer token"},
+        transport=httpx.MockTransport(handler),
+        timeout=5.0,
+    )
+    return a
+
+
+_CONTACT_JSON = {
+    "id": "cid-1",
+    "displayName": "Alice",
+    "lastModifiedDateTime": "2026-01-01T00:00:00Z",
+}
+
+
+def _route(path_predicates):
+    """Build an httpx MockTransport handler from {match_substring: response}."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        for sub, resp in path_predicates.items():
+            if sub in str(request.url):
+                return resp
+        return httpx.Response(404, json={"error": "no route"}, request=request)
+    return handler
+
+
+@pytest.fixture
+def caplog_warn(caplog):
+    caplog.set_level(
+        logging.WARNING,
+        logger="groupware_sync_contacts.adapters.graph_adapter",
+    )
+    return caplog
+
+
+def test_photo_404_does_not_log_warning(caplog_warn):
+    handler = _route({
+        "/photo/$value": httpx.Response(404, request=httpx.Request("GET", "x")),
+        "/contacts/cid-1": httpx.Response(200, json=_CONTACT_JSON,
+                                          request=httpx.Request("GET", "x")),
+    })
+    adapter = _adapter_with_handler(handler)
+    items = adapter.get_items("folder", ["cid-1"])
+    assert len(items) == 1
+    assert "photo" not in items[0].fields
+    photo_warnings = [r for r in caplog_warn.records if "photo" in r.getMessage()]
+    assert photo_warnings == []
+
+
+def test_photo_500_logs_warning_with_status(caplog_warn):
+    handler = _route({
+        "/photo/$value": httpx.Response(500, request=httpx.Request("GET", "x")),
+        "/contacts/cid-1": httpx.Response(200, json=_CONTACT_JSON,
+                                          request=httpx.Request("GET", "x")),
+    })
+    adapter = _adapter_with_handler(handler)
+    items = adapter.get_items("folder", ["cid-1"])
+    assert len(items) == 1
+    photo_warnings = [r for r in caplog_warn.records if "photo" in r.getMessage()]
+    assert len(photo_warnings) == 1
+    msg = photo_warnings[0].getMessage()
+    assert "cid-1" in msg
+    assert "500" in msg
+
+
+def test_photo_transport_error_logs_warning_with_traceback(caplog_warn):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/photo/$value" in str(request.url):
+            raise httpx.ConnectError("boom", request=request)
+        return httpx.Response(200, json=_CONTACT_JSON, request=request)
+
+    adapter = _adapter_with_handler(handler)
+    items = adapter.get_items("folder", ["cid-1"])
+    # Contact is still returned even though photo fetch blew up.
+    assert len(items) == 1
+    photo_warnings = [r for r in caplog_warn.records if "photo" in r.getMessage()]
+    assert len(photo_warnings) == 1
+    rec = photo_warnings[0]
+    assert "cid-1" in rec.getMessage()
+    # exc_info=True must be honoured so the traceback is in the record.
+    assert rec.exc_info is not None
+
+
+def test_photo_200_populates_fields(caplog_warn):
+    handler = _route({
+        "/photo/$value": httpx.Response(
+            200, content=b"\xff\xd8\xff",
+            headers={"content-type": "image/jpeg"},
+            request=httpx.Request("GET", "x"),
+        ),
+        "/contacts/cid-1": httpx.Response(200, json=_CONTACT_JSON,
+                                          request=httpx.Request("GET", "x")),
+    })
+    adapter = _adapter_with_handler(handler)
+    items = adapter.get_items("folder", ["cid-1"])
+    assert items[0].fields["photo_type"] == "image/jpeg"
+    assert items[0].fields["photo"]  # base64 string, non-empty
+    photo_warnings = [r for r in caplog_warn.records if "photo" in r.getMessage()]
+    assert photo_warnings == []


### PR DESCRIPTION
## Summary

Closes #20, #21, #23 from the 2026-04-27 audit in one PR.

- **#20 (HIGH)** — wire CardDAV/CalDAV adapters into the CLI/config. The adapters were already implemented and advertised in the README but unreachable. Adds per-side backend selectors (`SYNC_SIDE_{A,B}_BACKEND` env vars + `--side-{a,b}-backend` CLI flags), DAV credential env vars (`SYNC_SIDE_{A,B}_DAV_{URL,USERNAME,PASSWORD}`), and dispatch in both CLIs. Default `jmap`+`graph` topology preserved so existing deployments are unaffected.
- **#21 (MEDIUM)** — document `SyncOp.node_id` semantics. `node_id` is the *source*-side id for `CREATE_ITEM` but the *target*-side id for `DELETE_ITEM`, an inconsistency the auditor had to re-derive. Pinned by two regression tests that exercise the convention end-to-end through `compare_trees` and `_execute_delete`.
- **#23 (MEDIUM)** — photo-fetch errors in `GraphContactAdapter.get_items` no longer disappear into a bare `except: pass`. 404 stays silent (no photo is the common case), other HTTP statuses log a warning with the status code, transport/parse exceptions log a warning with traceback.

## Test plan

- [x] `pytest tests/test_engine_regression.py` — 7 passed (2 new DELETE_ITEM dispatch tests added)
- [x] `pytest tests/test_graph_contact_photo_logging.py` — 4 passed (200/404/500/transport-error)
- [x] `pytest tests/test_cli_backend_dispatch.py` — 7 passed, 2 skipped (vobject env)
- [x] `pytest tests/test_config_backends.py` — 5 passed
- [x] `pytest tests/test_cli_contacts.py tests/test_cli_calendar.py` — 12 passed (existing CLI tests still green after Config gained 4 fields)
- [x] Full unit suite (excluding e2e + 3 vobject-gated files): 265 passed, 2 skipped
- [ ] Manual smoke: a real CardDAV-backed sync against Radicale to confirm the dispatch path runs end-to-end